### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,7 @@
                     <button class="action-btn primary" onclick="todoApp.openAddTaskModal()">
                         <span>➕</span> New Task
                     </button>
+                    <button class="action-btn secondary" id="themeToggle">🌙</button>
                     <div class="view-controls">
                         <button class="view-btn active" data-view="kanban">📋</button>
                         <button class="view-btn" data-view="list">📄</button>

--- a/script.js
+++ b/script.js
@@ -14,6 +14,7 @@ class MumatecTaskManager {
 
     init() {
         this.loadTasks();
+        this.loadTheme();
         this.setupEventListeners();
         this.setupDragAndDrop();
         this.setupKeyboardShortcuts();
@@ -718,6 +719,11 @@ class MumatecTaskManager {
             this.importFromCSV(e);
         });
 
+        // Theme toggle
+        document.getElementById('themeToggle').addEventListener('click', () => {
+            this.toggleTheme();
+        });
+
         // Modal close on outside click
         document.querySelectorAll('.modal-overlay').forEach(modal => {
             modal.addEventListener('click', (e) => {
@@ -1064,6 +1070,28 @@ class MumatecTaskManager {
         
         result.push(current.trim());
         return result;
+    }
+
+    // Theme Management
+    loadTheme() {
+        const saved = localStorage.getItem('mumatecTheme');
+        if (saved === 'dark') {
+            document.body.classList.add('dark-mode');
+        }
+        this.updateThemeToggleIcon();
+    }
+
+    toggleTheme() {
+        const isDark = document.body.classList.toggle('dark-mode');
+        localStorage.setItem('mumatecTheme', isDark ? 'dark' : 'light');
+        this.updateThemeToggleIcon();
+    }
+
+    updateThemeToggleIcon() {
+        const btn = document.getElementById('themeToggle');
+        if (btn) {
+            btn.textContent = document.body.classList.contains('dark-mode') ? '☀️' : '🌙';
+        }
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1221,3 +1221,16 @@ body {
         --shadow-hover: rgba(0, 0, 0, 0.4);
     }
 }
+
+/* Manual dark mode toggle */
+body.dark-mode {
+    --background: #1C1C1E;
+    --surface: #2C2C2E;
+    --surface-secondary: #3A3A3C;
+    --text-primary: rgba(0, 178, 248, 0.973);
+    --text-secondary: #98989D;
+    --text-tertiary: #636366;
+    --border: #38383A;
+    --shadow: rgba(0, 0, 0, 0.2);
+    --shadow-hover: rgba(0, 0, 0, 0.4);
+}


### PR DESCRIPTION
## Summary
- add manual dark mode variables to CSS
- add a toggle button in the top bar
- implement theme load/toggle logic in JS

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68404a031004832eb6a70b26056c4342