### PR TITLE
Add Firebase auth and login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# MumatecTasking
+# Mumatec Tasking
+
+Simple task manager app with Firebase authentication.
+
+## Setup
+
+1. Serve the files using any static server (e.g. `npx serve`).
+2. Visit `login.html` to sign in with your admin credentials.
+3. After signing in you will be redirected to `index.html`.
+
+Firebase is pre-configured with project **mumatectasking-a381f**. Update `firebase.js` if you need to change configuration.

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,15 @@
+import { auth } from './firebase.js';
+import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js';
+
+onAuthStateChanged(auth, (user) => {
+  window.currentUser = user;
+  if (user) {
+    if (typeof window.initTodoApp === 'function') {
+      window.initTodoApp();
+    }
+  } else {
+    window.location.href = 'login.html';
+  }
+});
+
+window.logout = () => signOut(auth);

--- a/firebase.js
+++ b/firebase.js
@@ -1,0 +1,17 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js';
+import { getAuth } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js';
+import { getFirestore } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js';
+
+const firebaseConfig = {
+  apiKey: "AIzaSyBfXDEcfgOIGjQ8EatsfXg7BbImSjvgv5U",
+  authDomain: "mumatectasking-a381f.firebaseapp.com",
+  projectId: "mumatectasking-a381f",
+  storageBucket: "mumatectasking-a381f.firebasestorage.app",
+  messagingSenderId: "659745805145",
+  appId: "1:659745805145:web:abb6f7a2629978846e7248",
+  measurementId: "G-BFBY59K73J"
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getFirestore(app);

--- a/index.html
+++ b/index.html
@@ -124,6 +124,7 @@
                         <span>➕</span> New Task
                     </button>
                     <button class="action-btn secondary" id="themeToggle">🌙</button>
+                    <button class="action-btn secondary" onclick="logout()">Logout</button>
                     <div class="view-controls">
                         <button class="view-btn active" data-view="kanban">📋</button>
                         <button class="view-btn" data-view="list">📄</button>
@@ -368,5 +369,7 @@
     <div class="notification-container" id="notificationContainer"></div>
 
     <script src="script.js"></script>
+    <script type="module" src="firebase.js"></script>
+    <script type="module" src="auth.js"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login - Mumatec Tasking</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    body { display: flex; align-items: center; justify-content: center; height: 100vh; }
+    .login-container { width: 300px; padding: 20px; border: 1px solid #ccc; border-radius: 6px; background: #fff; }
+    .login-container h2 { text-align: center; margin-bottom: 1rem; }
+    .login-container input { width: 100%; padding: 0.5rem; margin-bottom: 1rem; }
+    .login-container button { width: 100%; padding: 0.5rem; }
+    .error { color: red; text-align: center; margin-top: 0.5rem; }
+  </style>
+</head>
+<body>
+  <div class="login-container">
+    <h2>Admin Login</h2>
+    <form id="loginForm">
+      <input type="email" id="email" placeholder="Email" required />
+      <input type="password" id="password" placeholder="Password" required />
+      <button type="submit">Login</button>
+      <div id="error" class="error"></div>
+    </form>
+  </div>
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="login.js"></script>
+</body>
+</html>

--- a/login.js
+++ b/login.js
@@ -1,0 +1,16 @@
+import { auth } from './firebase.js';
+import { signInWithEmailAndPassword } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js';
+
+document.getElementById('loginForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = document.getElementById('email').value.trim();
+  const password = document.getElementById('password').value;
+  const errorEl = document.getElementById('error');
+  errorEl.textContent = '';
+  try {
+    await signInWithEmailAndPassword(auth, email, password);
+    window.location.href = 'index.html';
+  } catch (err) {
+    errorEl.textContent = err.message;
+  }
+});

--- a/script.js
+++ b/script.js
@@ -1095,8 +1095,16 @@ class MumatecTaskManager {
     }
 }
 
-// Initialize the application
+// Initialize the application after authentication
+window.initTodoApp = function () {
+    if (!window.todoApp) {
+        window.todoApp = new MumatecTaskManager();
+        console.log('🚀 Mumatec Task Manager initialized successfully!');
+    }
+};
+
 document.addEventListener('DOMContentLoaded', () => {
-    window.todoApp = new MumatecTaskManager();
-    console.log('🚀 Mumatec Task Manager initialized successfully!');
+    if (window.currentUser) {
+        window.initTodoApp();
+    }
 });


### PR DESCRIPTION
## Summary
- implement Firebase config module
- add admin login page with email/password
- guard `index.html` with auth redirect
- allow signing out from the app
- update README with instructions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842a4c2ae08832e9415eb915d2e0964