### PR TITLE
Implement basic board management

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Simple task manager app with Firebase authentication.
 
 1. Serve the files using any static server (e.g. `npx serve`).
 2. Visit `login.html` to sign in with your admin credentials.
-3. After signing in you will be redirected to `index.html`.
+3. After signing in you will be redirected to `boards.html` where you can manage your boards.
 
 Firebase is pre-configured with project **mumatectasking-a381f**. Update `firebase.js` if you need to change configuration.

--- a/board.html
+++ b/board.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Board - Mumatec Tasking</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="board-page">
+    <h1 id="boardTitle"></h1>
+    <div id="listsContainer" class="lists-container"></div>
+    <form id="addListForm" class="list-form">
+      <input type="text" id="listTitle" placeholder="New list" required />
+      <button type="submit">Add List</button>
+    </form>
+  </div>
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="board.js"></script>
+  <script type="module" src="auth.js"></script>
+</body>
+</html>

--- a/board.js
+++ b/board.js
@@ -1,0 +1,87 @@
+import { db } from './firebase.js';
+import {
+  doc,
+  getDoc,
+  collection,
+  query,
+  orderBy,
+  onSnapshot,
+  addDoc,
+  Timestamp
+} from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js';
+
+const params = new URLSearchParams(window.location.search);
+const boardId = params.get('id');
+const boardTitleEl = document.getElementById('boardTitle');
+const listsContainer = document.getElementById('listsContainer');
+const addListForm = document.getElementById('addListForm');
+
+async function loadBoard() {
+  const boardRef = doc(db, 'boards', boardId);
+  const snap = await getDoc(boardRef);
+  if (snap.exists()) {
+    boardTitleEl.textContent = snap.data().title;
+    loadLists();
+  }
+}
+
+function loadLists() {
+  const listsCol = collection(db, 'boards', boardId, 'lists');
+  const q = query(listsCol, orderBy('order'));
+  onSnapshot(q, snap => {
+    listsContainer.innerHTML = '';
+    snap.forEach(d => {
+      const list = d.data();
+      const div = document.createElement('div');
+      div.className = 'board-list';
+      div.innerHTML = `
+        <h3>${list.title}</h3>
+        <div class="cards" id="cards-${d.id}"></div>
+        <form data-list="${d.id}" class="add-card-form">
+          <input type="text" placeholder="Add card" required />
+        </form>
+      `;
+      listsContainer.appendChild(div);
+      loadCards(d.id);
+    });
+  });
+}
+
+function loadCards(listId) {
+  const cardsCol = collection(db, 'boards', boardId, 'lists', listId, 'cards');
+  const q = query(cardsCol, orderBy('order'));
+  onSnapshot(q, snap => {
+    const container = document.getElementById(`cards-${listId}`);
+    if (!container) return;
+    container.innerHTML = '';
+    snap.forEach(c => {
+      const card = c.data();
+      const cardDiv = document.createElement('div');
+      cardDiv.className = 'card-item';
+      cardDiv.textContent = card.title;
+      container.appendChild(cardDiv);
+    });
+  });
+}
+
+if (addListForm) {
+  addListForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const title = document.getElementById('listTitle').value.trim();
+    const listsCol = collection(db, 'boards', boardId, 'lists');
+    await addDoc(listsCol, { title, order: Date.now() });
+    addListForm.reset();
+  });
+}
+
+listsContainer.addEventListener('submit', async e => {
+  if (!e.target.classList.contains('add-card-form')) return;
+  e.preventDefault();
+  const listId = e.target.getAttribute('data-list');
+  const title = e.target.querySelector('input').value.trim();
+  const cardsCol = collection(db, 'boards', boardId, 'lists', listId, 'cards');
+  await addDoc(cardsCol, { title, order: Date.now(), createdAt: Timestamp.now() });
+  e.target.reset();
+});
+
+loadBoard();

--- a/boards.html
+++ b/boards.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your Boards - Mumatec Tasking</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="boards-container">
+    <h1>Your Boards</h1>
+    <div id="boardsList"></div>
+    <form id="createBoardForm" class="board-form">
+      <input type="text" id="boardTitle" placeholder="Board title" required />
+      <textarea id="boardDesc" placeholder="Description"></textarea>
+      <select id="boardVisibility">
+        <option value="private">Private</option>
+        <option value="public">Public</option>
+      </select>
+      <button type="submit">Create Board</button>
+    </form>
+  </div>
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="boards.js"></script>
+  <script type="module" src="auth.js"></script>
+</body>
+</html>

--- a/boards.js
+++ b/boards.js
@@ -1,0 +1,58 @@
+import { db, auth } from './firebase.js';
+import {
+  collection,
+  addDoc,
+  onSnapshot,
+  query,
+  where,
+  Timestamp
+} from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js';
+
+const boardsListEl = document.getElementById('boardsList');
+const createForm = document.getElementById('createBoardForm');
+
+function renderBoards(boards) {
+  boardsListEl.innerHTML = '';
+  boards.forEach(b => {
+    const div = document.createElement('div');
+    div.className = 'board-item';
+    div.innerHTML = `
+      <h3>${b.title}</h3>
+      <p>${b.description || ''}</p>
+      <a href="board.html?id=${b.id}">Open</a>
+    `;
+    boardsListEl.appendChild(div);
+  });
+}
+
+function loadBoards() {
+  const user = auth.currentUser;
+  if (!user) return;
+  const q = query(collection(db, 'boards'), where('members', 'array-contains', user.uid));
+  onSnapshot(q, snap => {
+    const boards = [];
+    snap.forEach(doc => boards.push({ id: doc.id, ...doc.data() }));
+    renderBoards(boards);
+  });
+}
+
+if (createForm) {
+  createForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const title = document.getElementById('boardTitle').value.trim();
+    const description = document.getElementById('boardDesc').value.trim();
+    const visibility = document.getElementById('boardVisibility').value;
+    const user = auth.currentUser;
+    await addDoc(collection(db, 'boards'), {
+      title,
+      description,
+      visibility,
+      ownerId: user.uid,
+      members: [user.uid],
+      createdAt: Timestamp.now()
+    });
+    createForm.reset();
+  });
+}
+
+loadBoards();

--- a/login.js
+++ b/login.js
@@ -9,7 +9,7 @@ document.getElementById('loginForm').addEventListener('submit', async (e) => {
   errorEl.textContent = '';
   try {
     await signInWithEmailAndPassword(auth, email, password);
-    window.location.href = 'index.html';
+    window.location.href = 'boards.html';
   } catch (err) {
     errorEl.textContent = err.message;
   }

--- a/styles.css
+++ b/styles.css
@@ -1234,3 +1234,54 @@ body.dark-mode {
     --shadow: rgba(0, 0, 0, 0.2);
     --shadow-hover: rgba(0, 0, 0, 0.4);
 }
+
+/* Simple board and list styles */
+.boards-container {
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 1rem;
+}
+
+.board-item {
+    border: 1px solid var(--border);
+    padding: 0.75rem;
+    margin-bottom: 0.5rem;
+    background: var(--surface);
+}
+
+.board-item h3 {
+    margin-bottom: 0.25rem;
+}
+
+.board-form, .list-form {
+    margin-top: 1rem;
+    display: flex;
+    gap: 0.5rem;
+}
+
+.board-page {
+    max-width: 1000px;
+    margin: 2rem auto;
+    padding: 1rem;
+}
+
+.lists-container {
+    display: flex;
+    gap: 1rem;
+    overflow-x: auto;
+    padding-bottom: 1rem;
+}
+
+.board-list {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 0.5rem;
+    min-width: 200px;
+}
+
+.card-item {
+    padding: 0.25rem 0.5rem;
+    margin: 0.25rem 0;
+    background: var(--surface-secondary);
+    border: 1px solid var(--border);
+}


### PR DESCRIPTION
## Summary
- create board listing page and simple board view
- add boards.js and board.js to interact with Firestore
- redirect login to new boards page
- document new login flow
- add minimal board/list/card styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842bd375284832e83d01d92ebb35935