### PR TITLE
Fix Firebase config and board init bugs

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,6 +1,6 @@
 
 import { auth } from './firebase.js';
-import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js';
+import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
 
 
 onAuthStateChanged(auth, (user) => {

--- a/board.js
+++ b/board.js
@@ -8,10 +8,13 @@ import {
   onSnapshot,
   addDoc,
   Timestamp
-} from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js';
+} from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
 const params = new URLSearchParams(window.location.search);
 const boardId = params.get('id');
+if (!boardId) {
+  window.location.href = 'boards.html';
+}
 const boardTitleEl = document.getElementById('boardTitle');
 const listsContainer = document.getElementById('listsContainer');
 const addListForm = document.getElementById('addListForm');

--- a/boards.js
+++ b/boards.js
@@ -6,7 +6,8 @@ import {
   query,
   where,
   Timestamp
-} from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js';
+} from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
 
 const boardsListEl = document.getElementById('boardsList');
 const createForm = document.getElementById('createBoardForm');
@@ -35,6 +36,13 @@ function loadBoards() {
     renderBoards(boards);
   });
 }
+
+// Wait for auth state before loading boards
+onAuthStateChanged(auth, (user) => {
+  if (user) {
+    loadBoards();
+  }
+});
 
 if (createForm) {
   createForm.addEventListener('submit', async (e) => {

--- a/firebase.js
+++ b/firebase.js
@@ -1,14 +1,14 @@
 
-import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js';
-import { getAuth } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js';
-import { getFirestore } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js';
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-app.js';
+import { getAuth } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
+import { getFirestore } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
 
   const firebaseConfig = {
   apiKey: "AIzaSyDT01V2niUl83vaYXUEukc5fGzUppwfQEI",
   authDomain: "mumatectasking.firebaseapp.com",
   projectId: "mumatectasking",
-  storageBucket: "mumatectasking.firebasestorage.app",
+  storageBucket: "mumatectasking.appspot.com",
   messagingSenderId: "10382608024",
   appId: "1:10382608024:web:0d94eae7dcb524b40f32ed",
   measurementId: "G-57MJ7G5HX2"

--- a/login.js
+++ b/login.js
@@ -1,6 +1,6 @@
 import { auth } from './firebase.js';
 
-import { signInWithEmailAndPassword } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js';
+import { signInWithEmailAndPassword } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
 
 
 document.getElementById('loginForm').addEventListener('submit', async (e) => {


### PR DESCRIPTION
## Summary
- update Firebase imports to 11.9.0
- correct storage bucket URL
- redirect to boards page if board ID missing
- wait for auth state when loading boards
- use consistent Firebase version across auth scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842d5f76418832e8379122e0bfe54ba