### PR TITLE
Use Firestore for task storage

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -1,7 +1,7 @@
 
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-app.js';
 import { getAuth } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
-import { getFirestore } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+import { getFirestore, enableIndexedDbPersistence } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
 
   const firebaseConfig = {
@@ -18,6 +18,11 @@ import { getFirestore } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
+
+// Enable offline persistence for Firestore
+enableIndexedDbPersistence(db).catch((err) => {
+  console.warn('Firestore persistence error:', err);
+});
 
 // Expose for non-module scripts
 window.auth = auth;

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <div id="loadingOverlay" class="loading-overlay" style="display:none;">Loading...</div>
     <!-- App Shell -->
     <div class="app-container">
         <!-- Sidebar -->

--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 // Mumatec Task Manager - Professional Application
 import { db } from './firebase.js';
-import { collection, getDocs, setDoc, doc, deleteDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+import { collection, setDoc, doc, deleteDoc, onSnapshot } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 class MumatecTaskManager {
     constructor() {
         this.tasks = [];
@@ -36,38 +36,33 @@ class MumatecTaskManager {
 
     // Data Management
     async loadTasks() {
+        const loadingEl = document.getElementById('loadingOverlay');
+        if (loadingEl) loadingEl.style.display = 'flex';
         try {
             if (window.currentUser && db) {
                 const col = collection(db, 'users', window.currentUser.uid, 'tasks');
-                const snap = await getDocs(col);
-                const tasks = [];
-                snap.forEach(d => tasks.push({ id: d.id, ...d.data() }));
-                if (tasks.length) {
-                    this.tasks = tasks;
-                    localStorage.setItem('mumatecTasks', JSON.stringify(this.tasks));
-                    return;
-                }
-            }
-
-            const saved = localStorage.getItem('mumatecTasks');
-            if (saved) {
-                this.tasks = JSON.parse(saved);
+                this.unsubscribe = onSnapshot(col, (snap) => {
+                    this.tasks = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+                    this.updateUI();
+                    if (loadingEl) loadingEl.style.display = 'none';
+                }, (error) => {
+                    console.error('Error loading tasks:', error);
+                    this.showNotification('Error', 'Failed to load tasks', 'error');
+                    if (loadingEl) loadingEl.style.display = 'none';
+                });
             } else {
                 this.createSampleTasks();
+                if (loadingEl) loadingEl.style.display = 'none';
             }
         } catch (error) {
             console.error('Error loading tasks:', error);
-            this.showNotification('Error', 'Failed to load saved tasks', 'error');
+            this.showNotification('Error', 'Failed to load tasks', 'error');
+            if (loadingEl) loadingEl.style.display = 'none';
         }
     }
 
     saveTasks() {
-        try {
-            localStorage.setItem('mumatecTasks', JSON.stringify(this.tasks));
-        } catch (error) {
-            console.error('Error saving tasks:', error);
-            this.showNotification('Error', 'Failed to save tasks', 'error');
-        }
+        // Data persistence handled by Firestore; function retained for backward compatibility
     }
 
     async saveTaskToFirestore(task) {
@@ -127,7 +122,6 @@ class MumatecTaskManager {
         ];
         
         this.tasks = sampleTasks;
-        this.saveTasks();
         sampleTasks.forEach(task => this.saveTaskToFirestore(task));
     }
 
@@ -152,7 +146,6 @@ class MumatecTaskManager {
         };
 
         this.tasks.push(task);
-        this.saveTasks();
         this.saveTaskToFirestore(task);
         this.updateUI();
         this.showNotification('Success', 'Task created successfully', 'success');
@@ -175,7 +168,6 @@ class MumatecTaskManager {
             updatedAt: new Date().toISOString()
         };
 
-        this.saveTasks();
         this.saveTaskToFirestore(this.tasks[taskIndex]);
         this.updateUI();
         this.showNotification('Success', 'Task updated successfully', 'success');
@@ -184,7 +176,6 @@ class MumatecTaskManager {
 
     async deleteTask(taskId) {
         this.tasks = this.tasks.filter(task => task.id !== taskId);
-        this.saveTasks();
         this.deleteTaskFromFirestore(taskId);
         this.updateUI();
         this.showNotification('Success', 'Task deleted successfully', 'success');
@@ -197,7 +188,6 @@ class MumatecTaskManager {
         task.status = newStatus;
         task.updatedAt = new Date().toISOString();
         
-        this.saveTasks();
         this.saveTaskToFirestore(task);
         this.updateUI();
         return true;
@@ -868,11 +858,7 @@ class MumatecTaskManager {
     }
 
     setupAutoSave() {
-        setInterval(() => {
-            if (this.tasks.length > 0) {
-                this.saveTasks();
-            }
-        }, 30000); // Auto-save every 30 seconds
+        // Auto-save handled by Firestore real-time sync
     }
 
     // Form Handling
@@ -936,7 +922,7 @@ class MumatecTaskManager {
                 
                 if (hoursDiff <= 2 && hoursDiff > 0) {
                     task.reminderSent = true;
-                    this.saveTasks();
+                    this.saveTaskToFirestore(task);
                     
                     const message = `"${task.title}" is due in ${Math.ceil(hoursDiff)} hour${Math.ceil(hoursDiff) !== 1 ? 's' : ''}`;
                     this.showNotification('Task Reminder', message, 'warning');
@@ -1061,13 +1047,13 @@ class MumatecTaskManager {
                         } else {
                             this.tasks.push(task);
                         }
+                        this.saveTaskToFirestore(task);
                         importedCount++;
                     } catch (error) {
                         console.warn(`Error parsing line ${i + 1}:`, error);
                     }
                 }
 
-                this.saveTasks();
                 this.updateUI();
                 this.showNotification('Success', `Imported ${importedCount} tasks`, 'success');
             } catch (error) {

--- a/styles.css
+++ b/styles.css
@@ -1286,3 +1286,19 @@ body.dark-mode {
     border: 1px solid var(--border);
 }
 
+/* Loading Overlay */
+.loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 4000;
+    font-size: 1.2rem;
+    color: var(--text-primary);
+}
+


### PR DESCRIPTION
## Summary
- enable IndexedDB persistence for Firestore
- add loading overlay markup and styles
- store tasks directly in Firestore with real-time sync
- clean out localStorage persistence logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842dc04a074832e8ef007e25e440d2d