### PR TITLE
Improve responsive design

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
             <!-- Top Bar -->
             <div class="top-bar">
                 <div class="top-bar-left">
+                    <button class="menu-btn" id="menuToggle">☰</button>
                     <h1 class="page-title" id="pageTitle">Dashboard</h1>
                     <div class="page-subtitle" id="pageSubtitle">Welcome back! You have tasks to complete.</div>
                 </div>
@@ -118,7 +119,7 @@
                 </div>
 
                 <div class="top-bar-right">
-                    <button class="action-btn secondary" onclick="document.getElementById('csvImport').click()">
+                    <button class="action-btn secondary import-btn" onclick="document.getElementById('csvImport').click()">
                         <span>📥</span> Import
                     </button>
                     <button class="action-btn primary" onclick="todoApp.openAddTaskModal()">

--- a/script.js
+++ b/script.js
@@ -758,6 +758,14 @@ class MumatecTaskManager {
             this.toggleTheme();
         });
 
+        // Mobile menu toggle
+        const menuBtn = document.getElementById('menuToggle');
+        if (menuBtn) {
+            menuBtn.addEventListener('click', () => {
+                document.querySelector('.sidebar').classList.toggle('open');
+            });
+        }
+
         // Modal close on outside click
         document.querySelectorAll('.modal-overlay').forEach(modal => {
             modal.addEventListener('click', (e) => {

--- a/styles.css
+++ b/styles.css
@@ -269,6 +269,15 @@ body {
     min-width: 0;
 }
 
+.menu-btn {
+    display: none;
+    background: transparent;
+    border: none;
+    font-size: 24px;
+    margin-right: 12px;
+    cursor: pointer;
+}
+
 .page-title {
     font-size: 28px;
     font-weight: 700;
@@ -1170,6 +1179,19 @@ body {
     .sidebar.open {
         left: 0;
     }
+
+    .menu-btn {
+        display: block;
+    }
+
+    .top-bar-center {
+        display: none;
+    }
+
+    .import-btn,
+    .view-controls {
+        display: none;
+    }
     
     .main-content {
         margin-left: 0;
@@ -1179,9 +1201,6 @@ body {
         padding: 0 16px;
     }
     
-    .top-bar-center {
-        flex: 0 0 200px;
-    }
     
     .page-title {
         font-size: 24px;
@@ -1190,6 +1209,10 @@ body {
     .quick-stats {
         grid-template-columns: repeat(2, 1fr);
         gap: 12px;
+    }
+
+    .insights-panel {
+        display: none;
     }
     
     .kanban-container {
@@ -1204,6 +1227,20 @@ body {
     .form-row {
         grid-template-columns: 1fr;
         gap: 12px;
+    }
+}
+
+@media (max-width: 480px) {
+    .page-title {
+        font-size: 20px;
+    }
+
+    .action-btn span {
+        display: none;
+    }
+
+    .quick-stats {
+        display: none;
     }
 }
 


### PR DESCRIPTION
## Summary
- add menu toggle button for mobile navigation
- hide non-essential controls on smaller screens
- tweak layout for phones and tablets

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68434860a7d4832e84b7e538c3a7c16c