### PR TITLE
Add super admin and enhanced user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Simple task manager app with Firebase authentication and Firestore storage.
 
+The account **mumatechosting@gmail.com** is considered the super administrator
+and always has full rights to manage other users.
+
 ## Setup
 
 1. Serve the files using any static server (e.g. `npx serve`).
@@ -11,4 +14,13 @@ Simple task manager app with Firebase authentication and Firestore storage.
 Firebase is pre-configured with project **mumatectasking**. Update `firebase.js` if you need to change configuration.
 
 Tasks are stored in **Firebase Firestore** so they sync across devices. Offline changes are queued and saved once connectivity returns.
+
+### Admin features
+
+Admins can now:
+
+- Create and delete users
+- Grant or revoke admin rights
+- Edit any user's email or display name
+- Generate password reset links for users
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,7 +2,8 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     function isAdmin() {
-      return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin';
+      return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin'
+             || request.auth.token.email == 'mumatechosting@gmail.com';
     }
 
     match /{document=**} {

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,15 +1,42 @@
 const functions = require('firebase-functions');
-const admin     = require('firebase-admin');
+const admin = require('firebase-admin');
 admin.initializeApp();
 
-// Helper to confirm the caller is Admin
+const SUPER_ADMIN_EMAIL = 'mumatechosting@gmail.com';
+
+// Helper to confirm the caller is Admin. The email defined in
+// SUPER_ADMIN_EMAIL is always considered an admin even if no Firestore
+// document exists yet.
 async function checkAdmin(callerUid) {
   if (!callerUid) {
-    throw new functions.https.HttpsError('unauthenticated','Sign-in required.');
+    throw new functions.https.HttpsError('unauthenticated', 'Sign-in required.');
   }
+
+  const userRecord = await admin.auth().getUser(callerUid);
+
+  // If the authenticated user is the configured super admin email, ensure they
+  // have the admin role in Firestore and custom claims then allow.
+  if (userRecord.email === SUPER_ADMIN_EMAIL) {
+    const docRef = admin.firestore().doc(`users/${callerUid}`);
+    const snap = await docRef.get();
+    if (!snap.exists || snap.data().role !== 'admin') {
+      await docRef.set({
+        email: userRecord.email,
+        displayName: userRecord.displayName || '',
+        role: 'admin',
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true });
+    }
+    const claims = userRecord.customClaims || {};
+    if (claims.role !== 'admin') {
+      await admin.auth().setCustomUserClaims(callerUid, { role: 'admin' });
+    }
+    return;
+  }
+
   const docSnap = await admin.firestore().doc(`users/${callerUid}`).get();
   if (!docSnap.exists || docSnap.data().role !== 'admin') {
-    throw new functions.https.HttpsError('permission-denied','Admin only.');
+    throw new functions.https.HttpsError('permission-denied', 'Admin only.');
   }
 }
 
@@ -58,4 +85,32 @@ exports.deleteUserAccount = functions.https.onCall(async (data, context) => {
   await admin.auth().deleteUser(targetUid);
   await admin.firestore().doc(`users/${targetUid}`).delete();
   return { message: 'User deleted' };
+});
+
+// Update a user's basic profile information (email and display name).
+exports.updateUserProfile = functions.https.onCall(async (data, context) => {
+  await checkAdmin(context.auth.uid);
+  const { targetUid, email, displayName } = data;
+  if (!targetUid) {
+    throw new functions.https.HttpsError('invalid-argument', 'Missing targetUid');
+  }
+  const updateAuth = {};
+  if (email) updateAuth.email = email;
+  if (displayName) updateAuth.displayName = displayName;
+  if (Object.keys(updateAuth).length) {
+    await admin.auth().updateUser(targetUid, updateAuth);
+    await admin.firestore().doc(`users/${targetUid}`).set(updateAuth, { merge: true });
+  }
+  return { message: 'User profile updated' };
+});
+
+// Generate a password reset link for a user.
+exports.adminSendPasswordReset = functions.https.onCall(async (data, context) => {
+  await checkAdmin(context.auth.uid);
+  const { targetEmail } = data;
+  if (!targetEmail) {
+    throw new functions.https.HttpsError('invalid-argument', 'Missing targetEmail');
+  }
+  const link = await admin.auth().generatePasswordResetLink(targetEmail);
+  return { link };
 });


### PR DESCRIPTION
## Summary
- set `mumatechosting@gmail.com` as permanent super admin
- allow super admin to update role/claims automatically
- add cloud functions to update user profiles and send reset links
- extend Firestore rules to recognize super admin email
- add edit & reset password options in admin UI
- document admin capabilities in README

## Testing
- `npm --version` *(fails: no npm command)*

------
https://chatgpt.com/codex/tasks/task_e_68435d884ffc832ebbedc6ddaab6ba4a