### PR TITLE
Implement basic dashboard layout with Firestore data

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -30,7 +30,9 @@ onAuthStateChanged(auth, async (user) => {
     if (adminLink) {
       adminLink.style.display = role === 'admin' ? 'inline-block' : 'none';
     }
-    if (typeof window.initTodoApp === 'function') {
+    if (typeof window.initDashboard === 'function') {
+      window.initDashboard();
+    } else if (typeof window.initTodoApp === 'function') {
       window.initTodoApp();
     }
   } else {

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,108 @@
+import { db } from './firebase.js';
+import { collection, addDoc, query, where, getDocs, onSnapshot } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+
+class Dashboard {
+  constructor() {
+    this.tasksCol = null;
+    this.scheduleCol = null;
+    this.messagesCol = null;
+    this.chart = null;
+    this.init();
+  }
+
+  async init() {
+    if (window.currentUser) {
+      const uid = window.currentUser.uid;
+      this.tasksCol = collection(db, 'users', uid, 'tasks');
+      this.scheduleCol = collection(db, 'users', uid, 'schedule');
+      this.messagesCol = collection(db, 'users', uid, 'messages');
+      this.listen();
+      document.getElementById('createTask').addEventListener('click', () => this.addTask());
+    }
+  }
+
+  listen() {
+    onSnapshot(this.tasksCol, (snap) => {
+      const tasks = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+      this.renderTasks(tasks);
+      this.updateStats(tasks);
+      this.updateChart(tasks);
+    });
+    onSnapshot(this.scheduleCol, (snap) => {
+      const events = snap.docs.map(d => d.data());
+      this.renderSchedule(events);
+    });
+    onSnapshot(this.messagesCol, (snap) => {
+      const msgs = snap.docs.map(d => d.data());
+      this.renderMessages(msgs);
+    });
+  }
+
+  async addTask() {
+    const title = document.getElementById('newTaskTitle').value.trim();
+    if (!title) return;
+    await addDoc(this.tasksCol, { title, status: 'pending', createdAt: Date.now() });
+    document.getElementById('newTaskTitle').value = '';
+  }
+
+  renderTasks(tasks) {
+    const list = document.getElementById('taskList');
+    list.innerHTML = '';
+    tasks.forEach(t => {
+      const li = document.createElement('li');
+      li.textContent = t.title;
+      list.appendChild(li);
+    });
+  }
+
+  renderSchedule(events) {
+    const container = document.getElementById('scheduleList');
+    container.innerHTML = '';
+    events.forEach(ev => {
+      const div = document.createElement('div');
+      div.className = 'schedule-item';
+      div.textContent = `${ev.title} - ${ev.time}`;
+      container.appendChild(div);
+    });
+  }
+
+  renderMessages(msgs) {
+    const container = document.getElementById('messageList');
+    container.innerHTML = '';
+    msgs.forEach(m => {
+      const div = document.createElement('div');
+      div.className = 'message-item';
+      div.textContent = `${m.from}: ${m.text}`;
+      container.appendChild(div);
+    });
+  }
+
+  updateStats(tasks) {
+    const total = tasks.length;
+    const completed = tasks.filter(t => t.status === 'done').length;
+    const pending = total - completed;
+    document.getElementById('taskCount').textContent = total;
+    document.getElementById('completedCount').textContent = completed;
+    document.getElementById('pendingCount').textContent = pending;
+  }
+
+  updateChart(tasks) {
+    const ctx = document.getElementById('taskChart').getContext('2d');
+    const data = {};
+    tasks.forEach(t => {
+      const d = new Date(t.createdAt).toLocaleDateString();
+      data[d] = (data[d] || 0) + 1;
+    });
+    const labels = Object.keys(data);
+    const counts = Object.values(data);
+    if (this.chart) this.chart.destroy();
+    this.chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels, datasets: [{ label: 'Tasks', data: counts, fill: true, backgroundColor: 'rgba(0,122,255,0.2)', borderColor: '#007AFF' }] },
+      options: { scales: { y: { beginAtZero: true } } }
+    });
+  }
+}
+
+window.initDashboard = () => new Dashboard();
+

--- a/index.html
+++ b/index.html
@@ -3,429 +3,79 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Mumatec Task Manager</title>
+    <title>Mumatec Dashboard</title>
     <link rel="stylesheet" href="styles.css">
+    <style>
+        /* basic dashboard layout */
+        body{margin:0;background:#F8F9FA;font-family:Arial,Helvetica,sans-serif;}
+        .top-nav{position:fixed;top:0;left:0;right:0;height:60px;background:#fff;display:flex;align-items:center;justify-content:space-between;padding:0 20px;box-shadow:0 1px 4px rgba(0,0,0,0.1);z-index:1000;}
+        .top-nav .center{flex:1;text-align:center;}
+        .top-nav input{width:60%;padding:6px 10px;border:1px solid #ccc;border-radius:4px;}
+        .layout{display:flex;margin-top:60px;height:calc(100vh - 60px);}
+        .sidebar{width:60px;background:#fff;border-right:1px solid #ddd;display:flex;flex-direction:column;align-items:center;padding-top:20px;}
+        .sidebar .icon{margin:10px 0;cursor:pointer;color:#333;}
+        .main{flex:1;padding:20px;overflow-y:auto;}
+        .rightbar{width:300px;background:#fff;border-left:1px solid #ddd;padding:20px;overflow-y:auto;}
+        .stats{display:flex;gap:20px;margin-bottom:20px;}
+        .stat-card{background:#fff;border-radius:6px;box-shadow:0 1px 3px rgba(0,0,0,0.1);flex:1;padding:15px;text-align:center;}
+        .chart-container{background:#fff;border-radius:6px;box-shadow:0 1px 3px rgba(0,0,0,0.1);padding:20px;margin-bottom:20px;}
+        .tasks{background:#fff;border-radius:6px;box-shadow:0 1px 3px rgba(0,0,0,0.1);padding:0;list-style:none;margin:0;}
+        .tasks li{padding:10px;border-bottom:1px solid #eee;display:flex;align-items:center;justify-content:space-between;}
+        .tasks li:last-child{border-bottom:none;}
+        .schedule,.messages,.new-task{margin-bottom:20px;}
+        .schedule-item,.message-item{background:#fff;border-radius:6px;box-shadow:0 1px 3px rgba(0,0,0,0.1);padding:10px;margin-bottom:10px;}
+        .new-task input{width:100%;padding:6px;margin-bottom:10px;}
+        .new-task button{width:100%;padding:8px;background:#007AFF;color:#fff;border:none;border-radius:4px;cursor:pointer;}
+    </style>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
-    <div id="loadingOverlay" class="loading-overlay" style="display:none;">Loading...</div>
-    <!-- App Shell -->
-    <div class="app-container">
-        <!-- Sidebar -->
+    <div class="top-nav">
+        <div class="left"><strong>Mumatec</strong></div>
+        <div class="center"><input id="search" placeholder="Search"></div>
+        <div class="right">
+            <span id="notify">🔔</span>
+            <div id="profile" style="display:inline-block;margin-left:10px;cursor:pointer;">👤</div>
+        </div>
+    </div>
+    <div class="layout">
         <div class="sidebar">
-            <div class="sidebar-header">
-                <div class="app-logo">
-                    <div class="logo-icon">📋</div>
-                    <div class="logo-text">Mumatec Tasking</div>
-                </div>
-                <div class="user-info" id="userInfo" onclick="window.location.href='profile.html'">
-                    <div class="user-avatar" id="userAvatar">👤</div>
-                    <div class="user-details">
-                        <div class="user-name" id="userName">User</div>
-                        <div class="user-role" id="userRole">&nbsp;</div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="sidebar-nav">
-                <div class="nav-section">
-                    <div class="nav-item active" data-view="dashboard">
-                        <span class="nav-icon">🏠</span>
-                        <span class="nav-label">Dashboard</span>
-                        <span class="nav-count" id="dashboardCount">0</span>
-                    </div>
-                    <div class="nav-item" data-view="today">
-                        <span class="nav-icon">📅</span>
-                        <span class="nav-label">Today</span>
-                        <span class="nav-count" id="todayCount">0</span>
-                    </div>
-                    <div class="nav-item" data-view="upcoming">
-                        <span class="nav-icon">⏰</span>
-                        <span class="nav-label">Upcoming</span>
-                        <span class="nav-count" id="upcomingCount">0</span>
-                    </div>
-                    <div class="nav-item" data-view="completed">
-                        <span class="nav-icon">✅</span>
-                        <span class="nav-label">Completed</span>
-                        <span class="nav-count" id="completedNavCount">0</span>
-                    </div>
-                </div>
-
-                <div class="nav-divider"></div>
-
-                <div class="nav-section">
-                    <div class="nav-section-title">Projects</div>
-                    <div class="nav-item" data-filter="Work">
-                        <span class="nav-icon">💼</span>
-                        <span class="nav-label">Work</span>
-                        <span class="nav-count" id="workCount">0</span>
-                    </div>
-                    <div class="nav-item" data-filter="Personal">
-                        <span class="nav-icon">🏠</span>
-                        <span class="nav-label">Personal</span>
-                        <span class="nav-count" id="personalCount">0</span>
-                    </div>
-                    <div class="nav-item" data-filter="Development">
-                        <span class="nav-icon">💻</span>
-                        <span class="nav-label">Development</span>
-                        <span class="nav-count" id="devCount">0</span>
-                    </div>
-                </div>
-
-                <div class="nav-divider"></div>
-
-                <div class="nav-section">
-                    <div class="nav-item" onclick="todoApp.openQuickCapture()">
-                        <span class="nav-icon">⚡</span>
-                        <span class="nav-label">Quick Capture</span>
-                    </div>
-                    <div class="nav-item" onclick="todoApp.exportToCSV()">
-                        <span class="nav-icon">📤</span>
-                        <span class="nav-label">Export Data</span>
-                    </div>
-                </div>
-            </div>
-
-            <div class="sidebar-footer">
-                <div class="productivity-ring">
-                    <svg class="ring-progress" width="60" height="60">
-                        <circle cx="30" cy="30" r="25" fill="none" stroke="#f0f0f0" stroke-width="4"/>
-                        <circle cx="30" cy="30" r="25" fill="none" stroke="#007AFF" stroke-width="4" 
-                                stroke-dasharray="157" stroke-dashoffset="157" 
-                                transform="rotate(-90 30 30)" id="progressRing"/>
-                    </svg>
-                    <div class="ring-content">
-                        <span id="productivityPercent">0%</span>
-                    </div>
-                </div>
-                <div class="productivity-text">Today's Progress</div>
-            </div>
+            <div class="icon" data-view="dashboard">🏠</div>
+            <div class="icon" data-view="calendar">📅</div>
+            <div class="icon" data-view="projects">📁</div>
+            <div class="icon" data-view="messages">💬</div>
+            <div class="icon" data-view="analytics">📊</div>
+            <div class="icon" data-view="settings">⚙️</div>
         </div>
-
-        <!-- Main Content -->
-        <div class="main-content">
-            <!-- Top Bar -->
-            <div class="top-bar">
-                <div class="top-bar-left">
-                    <h1 class="page-title" id="pageTitle">Dashboard</h1>
-                   
-                </div>
-
-                <div class="top-bar-center">
-                    <div class="search-container">
-                        <input type="text" class="search-input" id="searchInput" placeholder="Search tasks...">
-                        <span class="search-icon">🔍</span>
-                    </div>
-                </div>
-
-                <div class="top-bar-right">
-                    <button class="action-btn secondary" onclick="document.getElementById('csvImport').click()">
-                        <span>📥</span> Import
-                    </button>
-                    <button class="action-btn primary" onclick="todoApp.openAddTaskModal()">
-                        <span>➕</span> New Task
-                    </button>
-                    <button class="action-btn secondary" id="themeToggle">🌙</button>
-                    <button class="action-btn secondary" id="profileLink" onclick="window.location.href='profile.html'">Profile</button>
-                    <button class="action-btn secondary" id="adminLink" style="display:none;" onclick="window.location.href='admin.html'">Admin</button>
-                    <button class="action-btn secondary" onclick="logout()">Logout</button>
-                    <div class="view-controls">
-                        <button class="view-btn active" data-view="kanban">📋</button>
-                        <button class="view-btn" data-view="list">📄</button>
-                    </div>
-                </div>
+        <div class="main">
+            <div class="stats">
+                <div class="stat-card"><div id="taskCount" style="font-size:24px;">0</div><div>Tasks</div></div>
+                <div class="stat-card"><div id="completedCount" style="font-size:24px;">0</div><div>Completed</div></div>
+                <div class="stat-card"><div id="pendingCount" style="font-size:24px;">0</div><div>Pending</div></div>
             </div>
-
-            <!-- Content Area -->
-            <div class="content-area">
-                <!-- Dashboard View -->
-                <div class="view-container active" id="dashboardView">
-                    <!-- Quick Stats -->
-                    <div class="quick-stats">
-                        <div class="stat-card">
-                            <div class="stat-icon">📋</div>
-                            <div class="stat-content">
-                                <div class="stat-number" id="totalTasks">0</div>
-                                <div class="stat-label">Total Tasks</div>
-                            </div>
-                        </div>
-                        <div class="stat-card">
-                            <div class="stat-icon">✅</div>
-                            <div class="stat-content">
-                                <div class="stat-number" id="completedTasks">0</div>
-                                <div class="stat-label">Completed</div>
-                            </div>
-                        </div>
-                        <div class="stat-card">
-                            <div class="stat-icon">⏳</div>
-                            <div class="stat-content">
-                                <div class="stat-number" id="pendingTasks">0</div>
-                                <div class="stat-label">In Progress</div>
-                            </div>
-                        </div>
-                        <div class="stat-card">
-                            <div class="stat-icon">🔥</div>
-                            <div class="stat-content">
-                                <div class="stat-number" id="streakDays">0</div>
-                                <div class="stat-label">Day Streak</div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Main Dashboard Content -->
-                    <div class="dashboard-grid">
-                        <!-- Kanban Board -->
-                        <div class="kanban-container">
-                            <div class="kanban-column" data-status="backlog">
-                                <div class="column-header">
-                                    <div class="column-title">Backlog</div>
-                                    <div class="column-count" id="backlogCount">0</div>
-                                </div>
-                                <div class="column-content" id="backlogBoard">
-                                    <div class="add-task-card" onclick="todoApp.openAddTaskModal('backlog')">
-                                        <span class="add-icon">➕</span>
-                                        <span>Add task</span>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="kanban-column" data-status="inprogress">
-                                <div class="column-header">
-                                    <div class="column-title">In Progress</div>
-                                    <div class="column-count" id="inprogressCount">0</div>
-                                </div>
-                                <div class="column-content" id="inprogressBoard">
-                                    <div class="add-task-card" onclick="todoApp.openAddTaskModal('inprogress')">
-                                        <span class="add-icon">➕</span>
-                                        <span>Add task</span>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="kanban-column" data-status="done">
-                                <div class="column-header">
-                                    <div class="column-title">Done</div>
-                                    <div class="column-count" id="doneCount">0</div>
-                                </div>
-                                <div class="column-content" id="doneBoard">
-                                    <div class="add-task-card" onclick="todoApp.openAddTaskModal('done')">
-                                        <span class="add-icon">➕</span>
-                                        <span>Add task</span>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="kanban-column" data-status="review">
-                                <div class="column-header">
-                                    <div class="column-title">Under Review</div>
-                                    <div class="column-count" id="reviewCount">0</div>
-                                </div>
-                                <div class="column-content" id="reviewBoard">
-                                    <div class="add-task-card" onclick="todoApp.openAddTaskModal('review')">
-                                        <span class="add-icon">➕</span>
-                                        <span>Add task</span>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="kanban-column" data-status="blocked">
-                                <div class="column-header">
-                                    <div class="column-title">Blocked</div>
-                                    <div class="column-count" id="blockedCount">0</div>
-                                </div>
-                                <div class="column-content" id="blockedBoard">
-                                    <div class="add-task-card" onclick="todoApp.openAddTaskModal('blocked')">
-                                        <span class="add-icon">➕</span>
-                                        <span>Add task</span>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="kanban-column" data-status="cancelled">
-                                <div class="column-header">
-                                    <div class="column-title">Cancelled</div>
-                                    <div class="column-count" id="cancelledCount">0</div>
-                                </div>
-                                <div class="column-content" id="cancelledBoard">
-                                    <div class="add-task-card" onclick="todoApp.openAddTaskModal('cancelled')">
-                                        <span class="add-icon">➕</span>
-                                        <span>Add task</span>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Insights Panel -->
-                        <div class="insights-panel">
-                            <div class="panel-header">
-                                <h3>📊 Insights</h3>
-                                <button class="panel-action">⋯</button>
-                            </div>
-                            <div class="insights-grid">
-                                <div class="insight-metric">
-                                    <div class="metric-label">This Week</div>
-                                    <div class="metric-value" id="weeklyCompleted">0</div>
-                                    <div class="metric-change positive" id="weeklyChange">+0%</div>
-                                </div>
-                                <div class="insight-metric">
-                                    <div class="metric-label">Average Daily</div>
-                                    <div class="metric-value" id="dailyAverage">0</div>
-                                    <div class="metric-trend">📈</div>
-                                </div>
-                                <div class="insight-metric">
-                                    <div class="metric-label">Most Productive</div>
-                                    <div class="metric-value" id="bestDay">Mon</div>
-                                    <div class="metric-trend">⭐</div>
-                                </div>
-                                <div class="insight-metric">
-                                    <div class="metric-label">Focus Score</div>
-                                    <div class="metric-value" id="focusScore">95%</div>
-                                    <div class="metric-trend">🎯</div>
-                                </div>
-                            </div>
-                            
-                            <div class="weekly-chart">
-                                <div class="chart-header">Weekly Activity</div>
-                                <div class="chart-bars" id="weeklyChart"></div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Other Views (Today, Upcoming, etc.) -->
-                <div class="view-container" id="todayView">
-                    <div class="today-content">
-                        <div class="today-header">
-                            <h2>Today's Focus</h2>
-                            <div class="today-date" id="todayDate"></div>
-                        </div>
-                        <div class="today-tasks" id="todayTasks"></div>
-                    </div>
-                </div>
-
-                <div class="view-container" id="upcomingView">
-                    <div class="upcoming-content">
-                        <h2>Upcoming Tasks</h2>
-                        <div class="upcoming-timeline" id="upcomingTimeline"></div>
-                    </div>
-                </div>
-
-                <div class="view-container" id="completedView">
-                    <div class="completed-content">
-                        <h2>Completed Tasks</h2>
-                        <div class="completed-list" id="completedList"></div>
-                    </div>
-                </div>
+            <div class="chart-container">
+                <canvas id="taskChart" height="150"></canvas>
+            </div>
+            <ul class="tasks" id="taskList"></ul>
+        </div>
+        <div class="rightbar">
+            <div class="schedule">
+                <h3>Today's schedule</h3>
+                <div id="scheduleList"></div>
+            </div>
+            <div class="messages">
+                <h3>Messages</h3>
+                <div id="messageList"></div>
+            </div>
+            <div class="new-task">
+                <h3>New Task</h3>
+                <input id="newTaskTitle" placeholder="Task title">
+                <button id="createTask">Create new</button>
             </div>
         </div>
     </div>
-
-    <!-- Quick Capture Modal -->
-    <div class="modal-overlay" id="quickCaptureModal">
-        <div class="quick-capture-modal">
-            <div class="quick-capture-header">
-                <h3>⚡ Quick Capture</h3>
-                <button class="close-btn" onclick="todoApp.closeQuickCapture()">✕</button>
-            </div>
-            <input type="text" class="quick-input" id="quickTaskInput" placeholder="What needs to be done?">
-            <div class="quick-actions">
-                <button class="quick-btn secondary" onclick="todoApp.closeQuickCapture()">Cancel</button>
-                <button class="quick-btn primary" onclick="todoApp.saveQuickTask()">Add Task</button>
-            </div>
-        </div>
-    </div>
-
-    <!-- Main Task Modal -->
-    <div class="modal-overlay" id="taskModal">
-        <div class="task-modal">
-            <div class="modal-header">
-                <h3 id="modalTitle">Add New Task</h3>
-                <button class="close-btn" onclick="todoApp.closeModal()">✕</button>
-            </div>
-            
-            <form id="taskForm" class="task-form">
-                <div class="form-section">
-                    <div class="form-field">
-                        <label>Task Title</label>
-                        <input type="text" id="taskTitle" required>
-                    </div>
-                    
-                    <div class="form-row">
-                        <div class="form-field">
-                            <label>Priority</label>
-                            <select id="taskPriority">
-                                <option value="low">🟢 Low</option>
-                                <option value="medium" selected>🟡 Medium</option>
-                                <option value="high">🔴 High</option>
-                                <option value="critical">❗ Critical</option>
-                            </select>
-                        </div>
-                        <div class="form-field">
-                            <label>Status</label>
-                            <select id="taskStatus">
-                                <option value="backlog">📋 Backlog</option>
-                                <option value="inprogress">⚡ In Progress</option>
-                                <option value="review">🔍 Under Review</option>
-                                <option value="done">✅ Done</option>
-                                <option value="blocked">⛔ Blocked</option>
-                                <option value="cancelled">❌ Cancelled</option>
-                            </select>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="form-section">
-                    <div class="form-field">
-                        <label>Description</label>
-                        <textarea id="taskDescription" rows="3"></textarea>
-                    </div>
-                </div>
-
-                <div class="form-section">
-                    <div class="form-row">
-                        <div class="form-field">
-                            <label>Due Date</label>
-                            <input type="datetime-local" id="taskDueDate">
-                        </div>
-                        <div class="form-field">
-                            <label>Category</label>
-                            <input type="text" id="taskCategory" placeholder="e.g., Work, Personal">
-                        </div>
-                        <div class="form-field">
-                            <label>Type</label>
-                            <select id="taskType">
-                                <option value="Maintenance">Maintenance</option>
-                                <option value="User Account Management">User Account Management</option>
-                                <option value="Access Control">Access Control</option>
-                                <option value="Security">Security</option>
-                                <option value="Compliance">Compliance</option>
-                            </select>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="form-section">
-                    <div class="form-field">
-                        <label>Tags</label>
-                        <input type="text" id="taskTags" placeholder="urgent, meeting, project">
-                    </div>
-                </div>
-
-                <div class="form-actions">
-                    <button type="button" class="form-btn secondary" onclick="todoApp.closeModal()">Cancel</button>
-                    <button type="submit" class="form-btn primary">Save Task</button>
-                </div>
-            </form>
-        </div>
-    </div>
-
-    <!-- File Input -->
-    <input type="file" id="csvImport" accept=".csv" style="display: none;">
-
-    <!-- Notifications -->
-    <div class="notification-container" id="notificationContainer"></div>
-
-    <script type="module" src="script.js"></script>
     <script type="module" src="firebase.js"></script>
+    <script type="module" src="dashboard.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace existing index.html with a simplified dashboard layout
- integrate Chart.js to show a task chart
- add new dashboard.js script for pulling tasks, messages and schedule from Firestore
- update auth.js to call the dashboard initializer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684371b9eaa8832ea8e8978ba1604006