### PR TITLE
Implement frontend-only admin management

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -4,7 +4,7 @@ import { getAuth } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth
 import { getFirestore, enableIndexedDbPersistence } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
 
-  const firebaseConfig = {
+export const firebaseConfig = {
   apiKey: "AIzaSyDT01V2niUl83vaYXUEukc5fGzUppwfQEI",
   authDomain: "mumatectasking.firebaseapp.com",
   projectId: "mumatectasking",


### PR DESCRIPTION
## Summary
- export firebaseConfig so it can be reused
- rework admin panel to rely on client auth and Firestore instead of Cloud Functions

## Testing
- `npm --version`
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6844954de364832e82ff4370f56e3582