### PR TITLE
Add modal-based insights panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
             <button class="action-btn primary" onclick="todoApp.openAddTaskModal()">
                 <span>➕</span> New Task
             </button>
+            <button class="action-btn secondary" id="insightsToggle" aria-label="Open insights" aria-haspopup="dialog">Insights</button>
             <button class="action-btn secondary" id="themeToggle">🌙</button>
             <button class="action-btn secondary" id="profileLink" onclick="window.location.href='profile.html'">Profile</button>
             <button class="action-btn secondary" id="adminLink" style="display:none;" onclick="window.location.href='admin.html'">Admin</button>
@@ -255,40 +256,6 @@
                             </div>
                         </div>
 
-                        <!-- Insights Panel -->
-                        <div class="insights-panel">
-                            <div class="panel-header">
-                                <h3>📊 Insights</h3>
-                                <button class="panel-action">⋯</button>
-                            </div>
-                            <div class="insights-grid">
-                                <div class="insight-metric">
-                                    <div class="metric-label">This Week</div>
-                                    <div class="metric-value" id="weeklyCompleted">0</div>
-                                    <div class="metric-change positive" id="weeklyChange">+0%</div>
-                                </div>
-                                <div class="insight-metric">
-                                    <div class="metric-label">Average Daily</div>
-                                    <div class="metric-value" id="dailyAverage">0</div>
-                                    <div class="metric-trend">📈</div>
-                                </div>
-                                <div class="insight-metric">
-                                    <div class="metric-label">Most Productive</div>
-                                    <div class="metric-value" id="bestDay">Mon</div>
-                                    <div class="metric-trend">⭐</div>
-                                </div>
-                                <div class="insight-metric">
-                                    <div class="metric-label">Focus Score</div>
-                                    <div class="metric-value" id="focusScore">95%</div>
-                                    <div class="metric-trend">🎯</div>
-                                </div>
-                            </div>
-                            
-                            <div class="weekly-chart">
-                                <div class="chart-header">Weekly Activity</div>
-                                <div class="chart-bars" id="weeklyChart"></div>
-                            </div>
-                        </div>
                     </div>
                 </div>
 
@@ -416,6 +383,43 @@
                     <button type="submit" class="form-btn primary">Save Task</button>
                 </div>
             </form>
+        </div>
+    </div>
+
+    <!-- Insights Modal -->
+    <div class="modal-overlay" id="insightsModal" role="dialog" aria-modal="true" aria-labelledby="insightsTitle">
+        <div class="insights-modal">
+            <div class="modal-header">
+                <h3 id="insightsTitle">📊 Insights</h3>
+                <button class="close-btn" id="insightsClose" aria-label="Close insights" onclick="todoApp.closeInsights()">✕</button>
+            </div>
+            <div class="insights-grid">
+                <div class="insight-metric">
+                    <div class="metric-label">This Week</div>
+                    <div class="metric-value" id="weeklyCompleted">0</div>
+                    <div class="metric-change positive" id="weeklyChange">+0%</div>
+                </div>
+                <div class="insight-metric">
+                    <div class="metric-label">Average Daily</div>
+                    <div class="metric-value" id="dailyAverage">0</div>
+                    <div class="metric-trend">📈</div>
+                </div>
+                <div class="insight-metric">
+                    <div class="metric-label">Most Productive</div>
+                    <div class="metric-value" id="bestDay">Mon</div>
+                    <div class="metric-trend">⭐</div>
+                </div>
+                <div class="insight-metric">
+                    <div class="metric-label">Focus Score</div>
+                    <div class="metric-value" id="focusScore">95%</div>
+                    <div class="metric-trend">🎯</div>
+                </div>
+            </div>
+
+            <div class="weekly-chart">
+                <div class="chart-header">Weekly Activity</div>
+                <div class="chart-bars" id="weeklyChart"></div>
+            </div>
         </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -605,6 +605,17 @@ class MumatecTaskManager {
         document.getElementById('quickTaskInput').value = '';
     }
 
+    openInsights() {
+        document.getElementById('insightsModal').classList.add('active');
+        this.renderWeeklyChart();
+        document.getElementById('insightsClose').focus();
+    }
+
+    closeInsights() {
+        document.getElementById('insightsModal').classList.remove('active');
+        document.getElementById('insightsToggle')?.focus();
+    }
+
     saveQuickTask() {
         const title = document.getElementById('quickTaskInput').value.trim();
         if (!title) return;
@@ -788,12 +799,23 @@ class MumatecTaskManager {
             this.toggleTheme();
         });
 
+        const insightsBtn = document.getElementById('insightsToggle');
+        if (insightsBtn) {
+            insightsBtn.addEventListener('click', () => this.openInsights());
+        }
+        const insightsClose = document.getElementById('insightsClose');
+        if (insightsClose) {
+            insightsClose.addEventListener('click', () => this.closeInsights());
+        }
+
         // Modal close on outside click
         document.querySelectorAll('.modal-overlay').forEach(modal => {
             modal.addEventListener('click', (e) => {
                 if (e.target === modal) {
                     if (modal.id === 'quickCaptureModal') {
                         this.closeQuickCapture();
+                    } else if (modal.id === 'insightsModal') {
+                        this.closeInsights();
                     } else {
                         this.closeModal();
                     }
@@ -844,6 +866,7 @@ class MumatecTaskManager {
             if (e.key === 'Escape') {
                 this.closeModal();
                 this.closeQuickCapture();
+                this.closeInsights();
             }
         });
     }

--- a/styles.css
+++ b/styles.css
@@ -484,7 +484,7 @@ body {
 /* Dashboard Grid */
 .dashboard-grid {
     display: grid;
-    grid-template-columns: 1fr 320px;
+    grid-template-columns: 1fr;
     gap: 24px;
     height: calc(100vh - var(--top-bar-height) - 120px);
 }
@@ -1008,6 +1008,19 @@ body {
     width: 90%;
     max-width: 600px;
     max-height: 90vh;
+    overflow-y: auto;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+    animation: modalSlideIn 0.3s ease;
+}
+
+/* Insights Modal */
+.insights-modal {
+    background: var(--background);
+    border-radius: var(--border-radius-lg);
+    width: 90%;
+    max-width: 600px;
+    max-height: 90vh;
+    padding: 24px;
     overflow-y: auto;
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
     animation: modalSlideIn 0.3s ease;


### PR DESCRIPTION
## Summary
- convert Insights panel to a modal dialog
- add Insights toggle button in the header
- adjust dashboard grid layout
- implement open/close logic for the Insights modal

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68448f2779dc832e918b20f19df3c6fc