### PR TITLE
Fix UI layout and insights functionality

### DIFF
--- a/script.js
+++ b/script.js
@@ -625,6 +625,7 @@ class MumatecTaskManager {
 
     openInsights() {
         document.getElementById('insightsModal').classList.add('active');
+        this.updateInsights();
         this.renderWeeklyChart();
         document.getElementById('insightsClose').focus();
     }

--- a/styles.css
+++ b/styles.css
@@ -81,7 +81,7 @@ body {
     height: calc(100vh - var(--top-bar-height));
     width: 100vw;
     position: relative;
-    margin-top: var(--top-bar-height);
+    margin-top: 0;
 }
 
 /* Sidebar */
@@ -427,7 +427,8 @@ body {
 /* Content Area */
 .content-area {
     flex: 1;
-    overflow: hidden;
+    overflow-x: auto;
+    overflow-y: hidden;
     position: relative;
 }
 
@@ -446,18 +447,18 @@ body {
 .quick-stats {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    gap: 16px;
-    margin-bottom: 24px;
+    gap: 12px;
+    margin-bottom: 16px;
 }
 
 .stat-card {
     background: var(--background);
     border: 1px solid var(--border);
     border-radius: var(--border-radius);
-    padding: 20px;
+    padding: 12px;
     display: flex;
     align-items: center;
-    gap: 16px;
+    gap: 8px;
     transition: var(--transition);
 }
 
@@ -467,25 +468,25 @@ body {
 }
 
 .stat-icon {
-    width: 48px;
-    height: 48px;
+    width: 32px;
+    height: 32px;
     background: var(--surface-secondary);
     border-radius: var(--border-radius);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 20px;
+    font-size: 16px;
 }
 
 .stat-number {
-    font-size: 32px;
+    font-size: 20px;
     font-weight: 700;
     color: var(--text-primary);
     line-height: 1;
 }
 
 .stat-label {
-    font-size: 12px;
+    font-size: 11px;
     color: var(--text-secondary);
     margin-top: 4px;
 }
@@ -508,6 +509,7 @@ body {
     overflow-y: hidden;
     align-items: flex-start;
     padding-bottom: 8px;
+    width: max-content;
 }
 
 .kanban-column {
@@ -1299,10 +1301,12 @@ body {
         flex-direction: column;
         overflow-x: hidden;
         gap: 12px;
+        width: 100%;
     }
     .kanban-column {
         flex-basis: 100%;
         min-width: auto;
+        width: 100%;
     }
     .kanban-column:not(:last-child)::after {
         display: none;


### PR DESCRIPTION
## Summary
- remove extra margin under sticky header
- allow horizontal scroll and responsive stacking for Kanban board
- shrink dashboard stat boxes
- update Insights modal to refresh metrics when opened

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844a7c1d0c4832ea8fe1e9554254bb7