### PR TITLE
Fix quick stats scrolling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -427,7 +427,7 @@ body {
 /* Content Area */
 .content-area {
     flex: 1;
-    overflow-x: auto;
+    overflow-x: hidden;
     overflow-y: hidden;
     position: relative;
 }
@@ -435,7 +435,8 @@ body {
 .view-container {
     display: none;
     height: 100%;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
     padding: 24px;
 }
 
@@ -497,6 +498,8 @@ body {
     grid-template-columns: 1fr;
     gap: 24px;
     height: calc(100vh - var(--top-bar-height) - 120px);
+    width: 100%;
+    overflow-x: auto;
 }
 
 /* Kanban Board */


### PR DESCRIPTION
## Summary
- prevent the entire content area from scrolling horizontally
- confine view containers to vertical scrolling only
- add width and horizontal scroll handling to `dashboard-grid`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844aba502d0832eb325f60fdd496e4d