### PR TITLE
Refactor task modal layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,13 +374,14 @@
                         </div>
                         <div class="form-field">
                             <label>Type</label>
-                            <select id="taskType">
-                                <option value="Maintenance">Maintenance</option>
-                                <option value="User Account Management">User Account Management</option>
-                                <option value="Access Control">Access Control</option>
-                                <option value="Security">Security</option>
-                                <option value="Compliance">Compliance</option>
-                            </select>
+                            <input type="text" id="taskType" list="typeSuggestions" placeholder="e.g., Maintenance">
+                            <datalist id="typeSuggestions">
+                                <option value="Maintenance">
+                                <option value="User Account Management">
+                                <option value="Access Control">
+                                <option value="Security">
+                                <option value="Compliance">
+                            </datalist>
                         </div>
                     </div>
                 </div>

--- a/script.js
+++ b/script.js
@@ -154,7 +154,7 @@ class MumatecTaskManager {
             status: taskData.status || 'todo',
             dueDate: taskData.dueDate || null,
             category: taskData.category?.trim() || 'Work',
-            type: taskData.type || 'Maintenance',
+            type: taskData.type || 'General',
             tags: this.parseTags(taskData.tags),
             createdAt: new Date().toISOString(),
             updatedAt: new Date().toISOString(),
@@ -180,7 +180,7 @@ class MumatecTaskManager {
             status: taskData.status || 'todo',
             dueDate: taskData.dueDate || null,
             category: taskData.category?.trim() || 'Work',
-            type: taskData.type || 'Maintenance',
+            type: taskData.type || 'General',
             tags: this.parseTags(taskData.tags),
             updatedAt: new Date().toISOString()
         };
@@ -391,7 +391,7 @@ class MumatecTaskManager {
             ${tagsHtml}
             <div class="task-meta">
                 <span class="task-category">${this.escapeHtml(task.category || 'Work')}</span>
-                <span class="task-type">${this.escapeHtml(task.type || 'Maintenance')}</span>
+                <span class="task-type">${this.escapeHtml(task.type || 'General')}</span>
                 ${task.dueDate ? `<span class="task-due ${isOverdue ? 'overdue' : ''}">${dueText}</span>` : ''}
             </div>
         `;
@@ -581,7 +581,7 @@ class MumatecTaskManager {
         document.getElementById('taskStatus').value = task.status;
         document.getElementById('taskDueDate').value = task.dueDate || '';
         document.getElementById('taskCategory').value = task.category || '';
-        document.getElementById('taskType').value = task.type || 'Maintenance';
+        document.getElementById('taskType').value = task.type || '';
         document.getElementById('taskTags').value = task.tags?.join(', ') || '';
         
         const modal = document.getElementById('taskModal');
@@ -605,7 +605,7 @@ class MumatecTaskManager {
         document.getElementById('taskStatus').value = 'todo';
         document.getElementById('taskDueDate').value = '';
         document.getElementById('taskCategory').value = '';
-        document.getElementById('taskType').value = 'Maintenance';
+        document.getElementById('taskType').value = '';
         document.getElementById('taskTags').value = '';
     }
 
@@ -639,7 +639,7 @@ class MumatecTaskManager {
         const title = document.getElementById('quickTaskInput').value.trim();
         if (!title) return;
 
-        this.addTask({ title, status: 'todo', category: 'Work', type: 'Maintenance' });
+        this.addTask({ title, status: 'todo', category: 'Work', type: 'General' });
         this.closeQuickCapture();
     }
 
@@ -1070,7 +1070,7 @@ class MumatecTaskManager {
                 task.status,
                 task.dueDate || '',
                 task.category || '',
-                task.type || 'Maintenance',
+                task.type || 'General',
                 task.tags ? task.tags.join(';') : '',
                 task.createdAt,
                 task.updatedAt || task.createdAt
@@ -1123,7 +1123,7 @@ class MumatecTaskManager {
                             status: this.statuses.includes(values[4]) ? values[4] : 'todo',
                             dueDate: values[5] || null,
                             category: values[6] || 'Work',
-                            type: values[7] || 'Maintenance',
+                            type: values[7] || 'General',
                             tags: values[8] ? values[8].split(';').map(tag => tag.trim()).filter(tag => tag) : [],
                             createdAt: values[9] || new Date().toISOString(),
                             updatedAt: values[10] || new Date().toISOString(),

--- a/styles.css
+++ b/styles.css
@@ -1061,6 +1061,9 @@ body {
     width: 90%;
     max-width: 600px;
     max-height: 90vh;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
     overflow-y: auto;
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
     animation: modalSlideIn 0.3s ease;
@@ -1096,11 +1099,14 @@ body {
 }
 
 .task-form {
-    padding: 0 24px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    padding: 0;
 }
 
 .form-section {
-    margin-bottom: 24px;
+    margin-bottom: 0;
 }
 
 .form-row {
@@ -1322,6 +1328,15 @@ body {
     .form-row {
         grid-template-columns: 1fr;
         gap: 12px;
+    }
+}
+
+@media (max-width: 480px) {
+    .task-modal {
+        width: 100%;
+        max-width: none;
+        height: 100%;
+        border-radius: 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- polish edit modal layout
- make type field a free text box with suggestions
- ensure defaults use generic type
- improve form spacing
- add mobile responsive style for modal

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684510d0ee78832e9a41ef077ba53c3f