### PR TITLE
Add extended profile fields and avatar upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@ and always has full rights to manage other users.
 
 1. Serve the files using any static server (e.g. `npx serve`).
 2. Visit `login.html` to sign in with your admin credentials.
-3. After signing in you will be redirected to `index.html` where you can manage your tasks.
+3. After signing in you will be redirected to `index.html` where you can manage
+your tasks.
 
-Firebase is pre-configured with project **mumatectasking**. Update `firebase.js` if you need to change configuration.
+Firebase is pre-configured with project **mumatectasking**. Update `firebase.js`
+ if you need to change configuration.
 
-Tasks are stored in **Firebase Firestore** so they sync across devices. Offline changes are queued and saved once connectivity returns.
+Tasks are stored in **Firebase Firestore** so they sync across devices. Offline
+changes are queued and saved once connectivity returns.
 
 ### Admin features
 
@@ -24,6 +27,12 @@ Admins can now:
 - Edit any user's email or display name
 - Generate password reset links for users
 
+### User profile features
+
+The profile page now supports avatar upload with cropping and extended details
+like job title, phone, timezone, skills, availability status and granular
+notification settings. Password changes are also available from the profile
+screen.
 
 ## Workflow Documentation
 For an overview of task statuses, priorities, and categories, see [WORKFLOW.md](./WORKFLOW.md).

--- a/profile.html
+++ b/profile.html
@@ -6,13 +6,15 @@
   <title>User Profile - Mumatec Tasking</title>
   <link rel="stylesheet" href="styles.css">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/cropperjs@1.5.13/dist/cropper.min.css" rel="stylesheet">
   <style>
     body { display: flex; align-items: center; justify-content: center; height: 100vh; }
-    .login-container { width: 300px; padding: 20px; border: 1px solid #ccc; border-radius: 6px; background: #fff; }
+    .login-container { width: 320px; padding: 20px; border: 1px solid #ccc; border-radius: 6px; background: #fff; overflow-y:auto; max-height:90vh; }
     .login-container h2 { text-align: center; margin-bottom: 1rem; }
-    .login-container input { width: 100%; padding: 0.5rem; margin-bottom: 1rem; }
+    .login-container input, .login-container select { width: 100%; padding: 0.5rem; margin-bottom: 1rem; }
     .login-container button { width: 100%; padding: 0.5rem; }
     .login-container label { display: block; margin-bottom: 0.5rem; }
+    #avatarPreview { width: 100%; max-height: 200px; margin-bottom:1rem; }
     .error { color: red; text-align: center; margin-top: 0.5rem; }
   </style>
 </head>
@@ -22,13 +24,33 @@
     <form id="profileForm">
       <input type="text" id="name" placeholder="Name" required />
       <input type="email" id="email" placeholder="Email" readonly />
-      <input type="text" id="photoURL" placeholder="Profile picture URL" />
-      <label><input type="checkbox" id="notifications" /> Email notifications</label>
+      <input type="file" id="avatar" accept="image/*" />
+      <img id="avatarPreview" style="display:none;"/>
+      <input type="text" id="jobTitle" placeholder="Job title" />
+      <input type="text" id="department" placeholder="Department" />
+      <input type="tel" id="phone" placeholder="Phone number" />
+      <input type="text" id="timezone" placeholder="Timezone" />
+      <input type="text" id="skills" placeholder="Skills (comma separated)" />
+      <select id="status">
+        <option value="online">Online</option>
+        <option value="offline">Offline</option>
+        <option value="away">Away</option>
+        <option value="busy">Busy</option>
+      </select>
+      <label><input type="checkbox" id="emailNotif" /> Email notifications</label>
+      <label><input type="checkbox" id="pushNotif" /> Push notifications</label>
       <button type="submit">Save</button>
       <div id="msg" class="error"></div>
     </form>
+    <h3>Security</h3>
+    <input type="password" id="newPassword" placeholder="New password" />
+    <input type="password" id="confirmPassword" placeholder="Confirm password" />
+    <button id="changePassword">Change Password</button>
+    <button id="setup2fa">Setup 2FA</button>
+    <div id="sessionInfo"></div>
   </div>
   <script type="module" src="firebase.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/cropperjs@1.5.13/dist/cropper.min.js"></script>
   <script type="module" src="profile.js"></script>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -8,9 +8,9 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <style>
     body { display: flex; align-items: center; justify-content: center; height: 100vh; }
-    .login-container { width: 300px; padding: 20px; border: 1px solid #ccc; border-radius: 6px; background: #fff; }
+    .login-container { width: 320px; padding: 20px; border: 1px solid #ccc; border-radius: 6px; background: #fff; }
     .login-container h2 { text-align: center; margin-bottom: 1rem; }
-    .login-container input { width: 100%; padding: 0.5rem; margin-bottom: 1rem; }
+    .login-container input, .login-container select { width: 100%; padding: 0.5rem; margin-bottom: 1rem; }
     .login-container button { width: 100%; padding: 0.5rem; }
     .error { color: red; text-align: center; margin-top: 0.5rem; }
   </style>
@@ -23,6 +23,19 @@
       <input type="email" id="email" placeholder="Email" required />
       <input type="password" id="password" placeholder="Password" required />
       <input type="text" id="photoURL" placeholder="Profile picture URL (optional)" />
+      <input type="text" id="jobTitle" placeholder="Job title" />
+      <input type="text" id="department" placeholder="Department" />
+      <input type="tel" id="phone" placeholder="Phone" />
+      <input type="text" id="timezone" placeholder="Timezone" />
+      <input type="text" id="skills" placeholder="Skills (comma separated)" />
+      <select id="status">
+        <option value="online">Online</option>
+        <option value="offline">Offline</option>
+        <option value="away">Away</option>
+        <option value="busy">Busy</option>
+      </select>
+      <label><input type="checkbox" id="emailNotif" checked /> Email notifications</label>
+      <label><input type="checkbox" id="pushNotif" /> Push notifications</label>
       <button type="submit">Sign Up</button>
       <div id="error" class="error"></div>
     </form>

--- a/signup.js
+++ b/signup.js
@@ -8,6 +8,14 @@ document.getElementById('signupForm').addEventListener('submit', async (e) => {
   const email = document.getElementById('email').value.trim();
   const password = document.getElementById('password').value;
   const photoURL = document.getElementById('photoURL').value.trim();
+  const jobTitle = document.getElementById('jobTitle').value.trim();
+  const department = document.getElementById('department').value.trim();
+  const phone = document.getElementById('phone').value.trim();
+  const timezone = document.getElementById('timezone').value.trim();
+  const skills = document.getElementById('skills').value.split(',').map(s => s.trim()).filter(Boolean);
+  const status = document.getElementById('status').value;
+  const emailNotif = document.getElementById('emailNotif').checked;
+  const pushNotif = document.getElementById('pushNotif').checked;
   const errorEl = document.getElementById('error');
   errorEl.textContent = '';
   try {
@@ -16,7 +24,13 @@ document.getElementById('signupForm').addEventListener('submit', async (e) => {
       name,
       email,
       photoURL: photoURL || null,
-      notifications: true
+      jobTitle,
+      department,
+      phone,
+      timezone,
+      skills,
+      status,
+      notifications: { email: emailNotif, push: pushNotif }
     });
     window.location.href = 'index.html';
   } catch (err) {


### PR DESCRIPTION
## Summary
- allow cropping an avatar image on the profile screen
- extend profile with contact details, skills, status and more
- add password change action and placeholder for 2FA
- capture the same fields during sign up
- document new profile features in README

## Testing
- `node --check profile.js`
- `node --check signup.js`


------
https://chatgpt.com/codex/tasks/task_e_6845127ac980832e9be184cf778cf585