### PR TITLE
Add custom role builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,13 @@ The application defines the following roles:
 - **client** – view only their own projects.
 - **guest** – limited read-only access.
 
+### Custom Role Builder
+
+Administrators can define additional roles with granular permissions using the new
+**Custom Role Builder** available from the admin panel. Roles can specify
+Create/Read/Update/Delete rights for Projects, Tasks, Users, Reports, Settings,
+Billing and Client Data. Resource level access can be limited to specific
+projects or clients and features may be toggled on or off per role.
+
 ## Workflow Documentation
 For an overview of task statuses, priorities, and categories, see [WORKFLOW.md](./WORKFLOW.md).

--- a/admin.html
+++ b/admin.html
@@ -14,6 +14,7 @@
 </head>
 <body>
   <h2>User Management</h2>
+  <p><a href="role-builder.html">Open Custom Role Builder</a></p>
   <div id="unauth" class="error" style="display:none;">You are not authorized.</div>
 
   <div id="adminControls" style="display:none;">

--- a/role-builder.html
+++ b/role-builder.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Custom Role Builder</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    body { padding:20px; }
+    table { width:100%; border-collapse:collapse; margin-top:1rem; }
+    th, td { border:1px solid #ccc; padding:6px; text-align:left; }
+    td.center { text-align:center; }
+  </style>
+</head>
+<body>
+  <h2>Create Custom Role</h2>
+  <input id="roleName" type="text" placeholder="Role name" />
+  <button id="createRole">Create</button>
+
+  <div id="roleEditor" style="display:none;">
+    <h3 id="editorTitle"></h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Resource</th>
+          <th class="center">Create</th>
+          <th class="center">Read</th>
+          <th class="center">Update</th>
+          <th class="center">Delete</th>
+          <th class="center">Feature Enabled</th>
+        </tr>
+      </thead>
+      <tbody id="permTable"></tbody>
+    </table>
+
+    <h4>Resource Access</h4>
+    <label>Projects: <input id="projectsAccess" placeholder="project IDs comma separated"></label><br>
+    <label>Clients: <input id="clientsAccess" placeholder="client IDs comma separated"></label><br>
+    <button id="saveRole">Save Role</button>
+  </div>
+
+  <h3>Existing Roles</h3>
+  <ul id="roleList"></ul>
+
+  <script type="module">
+    import { RoleBuilder, FEATURES, ACTIONS } from './role-builder.js';
+    const rb = new RoleBuilder();
+    const roleNameInput = document.getElementById('roleName');
+    const createBtn = document.getElementById('createRole');
+    const editor = document.getElementById('roleEditor');
+    const editorTitle = document.getElementById('editorTitle');
+    const permTable = document.getElementById('permTable');
+    const projectsInput = document.getElementById('projectsAccess');
+    const clientsInput = document.getElementById('clientsAccess');
+    const roleList = document.getElementById('roleList');
+    let currentRole = null;
+
+    function renderRoles() {
+      roleList.innerHTML = '';
+      rb.getAllRoles().forEach(r => {
+        const li = document.createElement('li');
+        const btn = document.createElement('button');
+        btn.textContent = 'Edit';
+        btn.onclick = () => editRole(r.name);
+        li.textContent = r.name + ' ';
+        li.appendChild(btn);
+        roleList.appendChild(li);
+      });
+    }
+
+    function editRole(name) {
+      currentRole = rb.getRole(name);
+      if (!currentRole) return;
+      editor.style.display = 'block';
+      editorTitle.textContent = name;
+      permTable.innerHTML = '';
+      FEATURES.forEach(res => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${res}</td>` + ACTIONS.map(a => `<td class="center"><input type="checkbox" data-res="${res}" data-act="${a}"></td>`).join('') + `<td class="center"><input type="checkbox" data-feature="${res}"></td>`;
+        permTable.appendChild(tr);
+      });
+      // populate existing values
+      FEATURES.forEach(res => {
+        ACTIONS.forEach(a => {
+          const cb = permTable.querySelector(`[data-res="${res}"][data-act="${a}"]`);
+          if (cb && currentRole.permissions[res]) {
+            cb.checked = !!currentRole.permissions[res][a];
+          }
+        });
+        const fcb = permTable.querySelector(`[data-feature="${res}"]`);
+        if (fcb) fcb.checked = !!currentRole.features[res];
+      });
+      projectsInput.value = currentRole.access.projects.join(',');
+      clientsInput.value = currentRole.access.clients.join(',');
+    }
+
+    createBtn.onclick = () => {
+      const name = roleNameInput.value.trim();
+      if (!name) return;
+      if (!rb.createRole(name)) {
+        alert('Role already exists');
+        return;
+      }
+      roleNameInput.value = '';
+      renderRoles();
+      editRole(name);
+    };
+
+    document.getElementById('saveRole').onclick = () => {
+      if (!currentRole) return;
+      FEATURES.forEach(res => {
+        ACTIONS.forEach(a => {
+          const cb = permTable.querySelector(`[data-res="${res}"][data-act="${a}"]`);
+          rb.setPermission(currentRole.name, res, a, cb.checked);
+        });
+        const fcb = permTable.querySelector(`[data-feature="${res}"]`);
+        rb.toggleFeature(currentRole.name, res, fcb.checked);
+      });
+      rb.setResourceAccess(currentRole.name, 'projects', projectsInput.value.split(',').map(v => v.trim()).filter(v => v));
+      rb.setResourceAccess(currentRole.name, 'clients', clientsInput.value.split(',').map(v => v.trim()).filter(v => v));
+      renderRoles();
+      alert('Role saved');
+    };
+
+    renderRoles();
+  </script>
+</body>
+</html>

--- a/role-builder.js
+++ b/role-builder.js
@@ -1,0 +1,87 @@
+// Role Builder module for managing custom roles and permissions
+
+export const FEATURES = ['projects', 'tasks', 'users', 'reports', 'settings', 'billing', 'clientData'];
+export const ACTIONS = ['create', 'read', 'update', 'delete'];
+
+function loadRoles() {
+  try {
+    return JSON.parse(localStorage.getItem('customRoles') || '[]');
+  } catch (_) {
+    return [];
+  }
+}
+
+function saveRoles(roles) {
+  localStorage.setItem('customRoles', JSON.stringify(roles));
+}
+
+export class RoleBuilder {
+  constructor() {
+    this.roles = loadRoles();
+  }
+
+  getRole(name) {
+    return this.roles.find(r => r.name === name) || null;
+  }
+
+  createRole(name) {
+    if (this.getRole(name)) return false;
+    const role = {
+      name,
+      permissions: {}, // { resource: { action: boolean } }
+      features: {},    // { feature: boolean }
+      access: { projects: [], clients: [] } // resource level ids
+    };
+    FEATURES.forEach(res => {
+      role.permissions[res] = {};
+      ACTIONS.forEach(a => { role.permissions[res][a] = false; });
+      role.features[res] = false;
+    });
+    this.roles.push(role);
+    saveRoles(this.roles);
+    return true;
+  }
+
+  setPermission(roleName, resource, action, allowed) {
+    const role = this.getRole(roleName);
+    if (!role || !FEATURES.includes(resource) || !ACTIONS.includes(action)) return;
+    role.permissions[resource][action] = !!allowed;
+    saveRoles(this.roles);
+  }
+
+  toggleFeature(roleName, feature, enabled) {
+    const role = this.getRole(roleName);
+    if (!role || !FEATURES.includes(feature)) return;
+    role.features[feature] = !!enabled;
+    saveRoles(this.roles);
+  }
+
+  setResourceAccess(roleName, type, ids) {
+    const role = this.getRole(roleName);
+    if (!role || !['projects','clients'].includes(type)) return;
+    role.access[type] = Array.isArray(ids) ? ids : [];
+    saveRoles(this.roles);
+  }
+
+  hasPermission(roleName, resource, action) {
+    const role = this.getRole(roleName);
+    if (!role) return false;
+    return !!(role.permissions[resource] && role.permissions[resource][action]);
+  }
+
+  featureEnabled(roleName, feature) {
+    const role = this.getRole(roleName);
+    if (!role) return false;
+    return !!role.features[feature];
+  }
+
+  getAccess(roleName, type) {
+    const role = this.getRole(roleName);
+    if (!role) return [];
+    return role.access[type] || [];
+  }
+
+  getAllRoles() {
+    return [...this.roles];
+  }
+}


### PR DESCRIPTION
## Summary
- create `role-builder.js` module for granular permissions, resource level access and feature toggles
- add `role-builder.html` UI to build custom roles
- link new builder from admin panel
- document custom role builder in README

## Testing
- `node -v`
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_68451a46b8b8832ea5945c557b48bc7b