### PR TITLE
Add user invitation and onboarding features

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Admins can now:
 - Activate or deactivate accounts
 - Impersonate users
 - Bulk update roles and invite users via CSV
+- Invite individual users with pre-assigned roles
+- Temporary guest access with automatic expiration
 - View audit logs of all admin actions
 - Manage teams, projects and client assignments
 
@@ -60,6 +62,13 @@ Administrators can define additional roles with granular permissions using the n
 Create/Read/Update/Delete rights for Projects, Tasks, Users, Reports, Settings,
 Billing and Client Data. Resource level access can be limited to specific
 projects or clients and features may be toggled on or off per role.
+
+## User Invitation & Onboarding
+
+Admins can send invites directly from `invite.html`. Invited users receive a password
+reset link and are assigned a role before their first login. Temporary guest
+accounts can include an expiration date. New users are guided through an
+onboarding checklist on first login and clients are shown a separate tutorial.
 
 
 ## Workflow Documentation

--- a/auth.js
+++ b/auth.js
@@ -17,6 +17,19 @@ onAuthStateChanged(auth, async (user) => {
         docData = snap.data();
         role = docData.role || null;
         if (!name) name = docData.displayName || docData.name || '';
+        if (docData.guestExpiresAt && docData.guestExpiresAt.toDate() < new Date()) {
+          alert('Your temporary access has expired.');
+          await signOut(auth);
+          return;
+        }
+        if (docData.onboarded === false && !location.pathname.endsWith('onboarding.html') && !location.pathname.endsWith('client-onboarding.html')) {
+          if (role === 'client') {
+            window.location.href = 'client-onboarding.html';
+          } else {
+            window.location.href = 'onboarding.html';
+          }
+          return;
+        }
       }
     } catch (e) {
       console.error('Failed to fetch user role', e);

--- a/client-onboarding.html
+++ b/client-onboarding.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Client Onboarding</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Welcome Client</h1>
+    <p>This brief tutorial will show you how to review your projects and provide feedback.</p>
+    <button id="clientDone">Continue</button>
+  </div>
+  <script type="module" src="client-onboarding.js"></script>
+</body>
+</html>

--- a/client-onboarding.js
+++ b/client-onboarding.js
@@ -1,0 +1,14 @@
+import { auth, db } from './firebase.js';
+import { doc, updateDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
+
+onAuthStateChanged(auth, async (user) => {
+  if (!user) {
+    window.location.href = 'login.html';
+    return;
+  }
+  document.getElementById('clientDone').addEventListener('click', async () => {
+    await updateDoc(doc(db, 'users', user.uid), { onboarded: true });
+    window.location.href = 'index.html';
+  });
+});

--- a/invite.html
+++ b/invite.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Invite User</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Invite User</h1>
+    <form id="inviteForm">
+      <label>Email <input type="email" id="inviteEmail" required></label><br>
+      <label>Display Name <input type="text" id="inviteName"></label><br>
+      <label>Role
+        <select id="inviteRole">
+          <option value="guest">guest</option>
+          <option value="client">client</option>
+          <option value="developer">developer</option>
+          <option value="designer">designer</option>
+          <option value="projectManager">projectManager</option>
+          <option value="teamLead">teamLead</option>
+          <option value="admin">admin</option>
+        </select>
+      </label><br>
+      <label>Expiration (days, optional) <input type="number" id="inviteDays" min="1"></label>
+      <button type="submit">Send Invite</button>
+    </form>
+    <pre id="inviteResult"></pre>
+  </div>
+  <script type="module" src="invite.js"></script>
+</body>
+</html>

--- a/invite.js
+++ b/invite.js
@@ -1,0 +1,21 @@
+import { functions } from './firebase.js';
+import { httpsCallable } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-functions.js';
+
+const form = document.getElementById('inviteForm');
+const result = document.getElementById('inviteResult');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = document.getElementById('inviteEmail').value.trim();
+  const displayName = document.getElementById('inviteName').value.trim();
+  const role = document.getElementById('inviteRole').value;
+  const days = parseInt(document.getElementById('inviteDays').value, 10);
+  const inviteFn = httpsCallable(functions, 'inviteUser');
+  try {
+    const expiresAt = days ? Date.now() + days * 86400000 : undefined;
+    const res = await inviteFn({ email, displayName, role, expiresAt });
+    result.textContent = `Invite link: ${res.data.link}`;
+  } catch (err) {
+    result.textContent = err.message;
+  }
+});

--- a/onboarding.html
+++ b/onboarding.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome Onboarding</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Welcome to Mumatec Tasking</h1>
+    <ol id="checklist">
+      <li>Create or update your profile information</li>
+      <li>Join your assigned projects and teams</li>
+      <li>Review the getting started tutorial</li>
+    </ol>
+    <button id="completeOnboarding">Get Started</button>
+  </div>
+  <script type="module" src="onboarding.js"></script>
+</body>
+</html>

--- a/onboarding.js
+++ b/onboarding.js
@@ -1,0 +1,14 @@
+import { auth, db } from './firebase.js';
+import { doc, updateDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
+
+onAuthStateChanged(auth, async (user) => {
+  if (!user) {
+    window.location.href = 'login.html';
+    return;
+  }
+  document.getElementById('completeOnboarding').addEventListener('click', async () => {
+    await updateDoc(doc(db, 'users', user.uid), { onboarded: true });
+    window.location.href = 'index.html';
+  });
+});


### PR DESCRIPTION
## Summary
- support inviting a single user with optional expiration in Cloud Functions
- redirect new users to onboarding pages and expire guest access on login
- add simple onboarding and client onboarding pages
- add admin invite page for individual invites
- document invitation and onboarding features

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68451eb01214832e9e320c0c5f24a148