### PR TITLE
Add user directory, messaging, org chart and presence

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,13 +1,15 @@
 
-import { auth, db, functions } from './firebase.js';
+import { auth, db, functions, initPresence, rtdb } from './firebase.js';
 import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
 import { doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 import { httpsCallable } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-functions.js';
+import { ref, set } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-database.js';
 
 
 onAuthStateChanged(auth, async (user) => {
   window.currentUser = user;
   if (user) {
+    initPresence(user.uid);
     let role = null;
     let name = user.displayName || '';
     let docData = null;
@@ -63,4 +65,11 @@ onAuthStateChanged(auth, async (user) => {
 });
 
 
-window.logout = () => signOut(auth);
+
+window.logout = () => {
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    set(ref(rtdb, `presence/${uid}`), { state: 'offline', lastChanged: Date.now() });
+  }
+  return signOut(auth);
+};

--- a/directory.html
+++ b/directory.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Company Directory - Mumatec Tasking</title>
+  <link rel="stylesheet" href="styles.css">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <style>
+    body { padding:20px; }
+    table { width:100%; border-collapse:collapse; margin-top:1rem; }
+    th, td { border:1px solid #ccc; padding:6px; text-align:left; }
+  </style>
+</head>
+<body>
+  <h2>Company Directory</h2>
+  <input type="text" id="search" placeholder="Search users or skills..." />
+  <table id="dirTable">
+    <thead>
+      <tr><th>Name</th><th>Email</th><th>Job Title</th><th>Skills</th><th>Status</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="directory.js"></script>
+</body>
+</html>

--- a/directory.js
+++ b/directory.js
@@ -1,0 +1,36 @@
+import { auth, db, rtdb } from './firebase.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
+import { collection, onSnapshot } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+import { ref, onValue } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-database.js';
+
+const tableBody = document.querySelector('#dirTable tbody');
+const searchInput = document.getElementById('search');
+let users = [];
+let presence = {};
+
+function render() {
+  const q = (searchInput.value || '').toLowerCase();
+  tableBody.innerHTML = '';
+  users.forEach(u => {
+    const skills = (u.skills || []).join(', ');
+    if (q && !u.email.toLowerCase().includes(q) && !(u.displayName || '').toLowerCase().includes(q) && !skills.toLowerCase().includes(q)) return;
+    const tr = document.createElement('tr');
+    const status = presence[u.id]?.state === 'online' ? 'Online' : 'Offline';
+    tr.innerHTML = `<td>${u.displayName || ''}</td><td>${u.email}</td><td>${u.jobTitle || ''}</td><td>${skills}</td><td>${status}</td>`;
+    tableBody.appendChild(tr);
+  });
+}
+
+searchInput.addEventListener('input', render);
+
+onAuthStateChanged(auth, user => {
+  if (!user) { window.location.href = 'login.html'; return; }
+  onSnapshot(collection(db, 'users'), snap => {
+    users = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+    render();
+  });
+  onValue(ref(rtdb, 'presence'), snap => {
+    presence = snap.val() || {};
+    render();
+  });
+});

--- a/firebase.js
+++ b/firebase.js
@@ -3,6 +3,7 @@ import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.9.0/firebas
 import { getAuth } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
 import { getFirestore, enableIndexedDbPersistence } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 import { getFunctions } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-functions.js';
+import { getDatabase, ref, onDisconnect, set } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-database.js';
 
 
 export const firebaseConfig = {
@@ -20,6 +21,7 @@ const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const functions = getFunctions(app);
+export const rtdb = getDatabase(app);
 
 // Enable offline persistence for Firestore
 enableIndexedDbPersistence(db).catch((err) => {
@@ -30,3 +32,11 @@ enableIndexedDbPersistence(db).catch((err) => {
 window.auth = auth;
 window.db = db;
 window.functions = functions;
+window.rtdb = rtdb;
+
+export function initPresence(uid) {
+  if (!uid) return;
+  const userRef = ref(rtdb, `presence/${uid}`);
+  set(userRef, { state: 'online', lastChanged: Date.now() });
+  onDisconnect(userRef).set({ state: 'offline', lastChanged: Date.now() });
+}

--- a/index.html
+++ b/index.html
@@ -38,6 +38,8 @@
             <button class="action-btn secondary" id="profileLink" onclick="window.location.href='profile.html'">Profile</button>
             <button class="action-btn secondary" id="adminLink" style="display:none;" onclick="window.location.href='admin.html'">Admin</button>
             <button class="action-btn secondary" id="orgLink" style="display:none;" onclick="window.location.href='org.html'">Org</button>
+            <button class="action-btn secondary" id="directoryLink" onclick="window.location.href='directory.html'">Directory</button>
+            <button class="action-btn secondary" id="messagesLink" onclick="window.location.href='messages.html'">Messages</button>
             <button class="action-btn secondary" onclick="logout()">Logout</button>
             <div class="view-controls">
                 <button class="view-btn active material-icons" data-view="kanban" aria-label="Kanban view" aria-pressed="true">view_kanban</button>

--- a/messages.html
+++ b/messages.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Messages - Mumatec Tasking</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    body { padding:20px; }
+    #messages { border:1px solid #ccc; height:300px; overflow-y:auto; margin-top:1rem; padding:4px; }
+    #userList button { margin-right:6px; margin-bottom:6px; }
+  </style>
+</head>
+<body>
+  <h2>Messages</h2>
+  <div id="userList"></div>
+  <div id="chatSection" style="display:none;">
+    <h3 id="chatWith"></h3>
+    <div id="messages"></div>
+    <form id="msgForm">
+      <input type="text" id="msgInput" placeholder="Type a message" required />
+      <button type="submit">Send</button>
+    </form>
+  </div>
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="messages.js"></script>
+</body>
+</html>

--- a/messages.js
+++ b/messages.js
@@ -1,0 +1,63 @@
+import { auth, db } from './firebase.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
+import { collection, getDocs, addDoc, query, orderBy, onSnapshot } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+
+const userList = document.getElementById('userList');
+const chatSection = document.getElementById('chatSection');
+const chatWith = document.getElementById('chatWith');
+const messagesEl = document.getElementById('messages');
+const msgForm = document.getElementById('msgForm');
+const msgInput = document.getElementById('msgInput');
+
+let currentUser = null;
+let currentTarget = null;
+let unsub = null;
+
+function convoId(a, b) {
+  return [a, b].sort().join('_');
+}
+
+async function loadUsers() {
+  const snap = await getDocs(collection(db, 'users'));
+  userList.innerHTML = '';
+  snap.forEach(docSnap => {
+    if (docSnap.id === currentUser.uid) return;
+    const d = docSnap.data();
+    const btn = document.createElement('button');
+    btn.textContent = d.displayName || d.email;
+    btn.addEventListener('click', () => openChat(docSnap.id, d));
+    userList.appendChild(btn);
+  });
+}
+
+function openChat(uid, data) {
+  currentTarget = uid;
+  chatWith.textContent = data.displayName || data.email;
+  chatSection.style.display = 'block';
+  if (unsub) unsub();
+  const q = query(collection(db, 'messages', convoId(currentUser.uid, uid), 'msgs'), orderBy('ts'));
+  unsub = onSnapshot(q, snap => {
+    messagesEl.innerHTML = '';
+    snap.forEach(m => {
+      const d = m.data();
+      const div = document.createElement('div');
+      div.textContent = `${d.from === currentUser.uid ? 'Me' : chatWith.textContent}: ${d.text}`;
+      messagesEl.appendChild(div);
+    });
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+  });
+}
+
+msgForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  if (!currentTarget || !msgInput.value.trim()) return;
+  const ref = collection(db, 'messages', convoId(currentUser.uid, currentTarget), 'msgs');
+  await addDoc(ref, { from: currentUser.uid, text: msgInput.value.trim(), ts: Date.now() });
+  msgInput.value = '';
+});
+
+onAuthStateChanged(auth, user => {
+  if (!user) { window.location.href = 'login.html'; return; }
+  currentUser = user;
+  loadUsers();
+});

--- a/org-chart.html
+++ b/org-chart.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Org Chart - Mumatec Tasking</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    body { padding:20px; }
+    ul { list-style: none; }
+    li { margin:4px 0; }
+  </style>
+</head>
+<body>
+  <h2>Organization Chart</h2>
+  <div id="chart"></div>
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="org-chart.js"></script>
+</body>
+</html>

--- a/org-chart.js
+++ b/org-chart.js
@@ -1,0 +1,46 @@
+import { auth, db } from './firebase.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
+import { collection, getDocs } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+
+const chartEl = document.getElementById('chart');
+
+function buildTree(users) {
+  const byId = {};
+  users.forEach(u => { byId[u.id] = { ...u, children: [] }; });
+  const roots = [];
+  users.forEach(u => {
+    const node = byId[u.id];
+    if (u.managerUid && byId[u.managerUid]) {
+      byId[u.managerUid].children.push(node);
+    } else {
+      roots.push(node);
+    }
+  });
+  return roots;
+}
+
+function renderNode(node) {
+  const li = document.createElement('li');
+  li.textContent = `${node.displayName || node.email}${node.jobTitle ? ' - ' + node.jobTitle : ''}`;
+  if (node.children.length) {
+    const ul = document.createElement('ul');
+    node.children.forEach(c => ul.appendChild(renderNode(c)));
+    li.appendChild(ul);
+  }
+  return li;
+}
+
+function renderTree(roots) {
+  chartEl.innerHTML = '';
+  const ul = document.createElement('ul');
+  roots.forEach(r => ul.appendChild(renderNode(r)));
+  chartEl.appendChild(ul);
+}
+
+onAuthStateChanged(auth, async user => {
+  if (!user) { window.location.href = 'login.html'; return; }
+  const snap = await getDocs(collection(db, 'users'));
+  const users = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+  const tree = buildTree(users);
+  renderTree(tree);
+});

--- a/org.html
+++ b/org.html
@@ -14,6 +14,7 @@
 </head>
 <body>
   <h2>Organization Management</h2>
+  <p><a href="org-chart.html">View Org Chart</a></p>
   <div id="unauthOrg" class="error" style="display:none;">You are not authorized.</div>
   <div id="orgControls" style="display:none;">
     <h3>Create Team</h3>


### PR DESCRIPTION
## Summary
- implement presence tracking using Realtime Database
- create searchable company directory showing presence and skills
- add real-time messaging between users
- visualize org chart built from manager assignments
- link new pages from the main UI

## Testing
- `python -m pip install -r requirements.txt` *(fails: no such file)*
- `npm test` *(fails: no package.json)*
- `python -m pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68452093ba44832ea4079ff7990f3b9e