### PR TITLE
Enhance user security features

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -7,23 +7,45 @@ service cloud.firestore {
              || request.auth.token.email == 'mumatechosting@gmail.com';
     }
 
+    function isTeamMember(teamId) {
+      return exists(/databases/$(database)/documents/teams/$(teamId)/members/$(request.auth.uid));
+    }
+
     match /{document=**} {
-      allow read, write: if request.auth != null;
+      allow read, write: if false;
     }
 
     match /users/{userId} {
-      allow read: if request.auth.uid == userId || isAdmin();
-      allow create: if isAdmin();
-      allow update: if isAdmin();
-      allow delete: if false;
+      allow read, write: if request.auth.uid == userId || isAdmin();
     }
 
     match /users/{userId}/tasks/{taskId} {
       allow read, write: if request.auth.uid == userId || isAdmin();
     }
 
-    match /boards/{boardId} {
-      allow read, write: if isAdmin() || (request.auth.uid in resource.data.members);
+    match /users/{userId}/sessions/{sessionId} {
+      allow read, write: if request.auth.uid == userId || isAdmin();
+    }
+
+    match /teams/{teamId} {
+      allow read, write: if isAdmin();
+    }
+
+    match /teams/{teamId}/members/{uid} {
+      allow read, write: if isAdmin() || uid == request.auth.uid;
+    }
+
+    match /clients/{clientId} {
+      allow read, write: if isAdmin();
+    }
+
+    match /projects/{projectId} {
+      allow read: if isAdmin() || isTeamMember(resource.data.teamId) || exists(/databases/$(database)/documents/projects/$(projectId)/members/$(request.auth.uid));
+      allow write: if isAdmin();
+    }
+
+    match /projects/{projectId}/members/{uid} {
+      allow read, write: if isAdmin() || uid == request.auth.uid;
     }
 
     match /auditLogs/{logId} {

--- a/profile.html
+++ b/profile.html
@@ -48,6 +48,7 @@
     <button id="changePassword">Change Password</button>
     <button id="setup2fa">Setup 2FA</button>
     <div id="sessionInfo"></div>
+    <ul id="sessionsList"></ul>
   </div>
   <script type="module" src="firebase.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/cropperjs@1.5.13/dist/cropper.min.js"></script>


### PR DESCRIPTION
## Summary
- add session tracking with Cloud Function `logUserSession`
- implement rate limiting helper used for create/invite actions
- tighten Firestore rules and add session collection
- show and manage active sessions in profile screen
- log session start/end in auth flow

## Testing
- `npm --version`
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_684523f7218c832eb9f6c2197942afd3