### PR TITLE
Improve mobile responsiveness and seed sample tasks

### DIFF
--- a/login.html
+++ b/login.html
@@ -7,13 +7,11 @@
   <link rel="stylesheet" href="styles.css">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <style>
-    body { display: flex; align-items: center; justify-content: center; height: 100vh; }
-    .login-container { width: 300px; padding: 20px; border: 1px solid #ccc; border-radius: 6px; background: #fff; }
+    body { display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; }
+    .login-container { width: 320px; max-width: 95%; padding: 20px; border: 1px solid #ccc; border-radius: 6px; background: #fff; }
     .login-container h2 { text-align: center; margin-bottom: 1rem; }
     .login-container input { width: 100%; padding: 0.5rem; margin-bottom: 1rem; }
     .login-container button { width: 100%; padding: 0.5rem; }
-
-
     .error { color: red; text-align: center; margin-top: 0.5rem; }
   </style>
 </head>

--- a/script.js
+++ b/script.js
@@ -12,6 +12,7 @@ class MumatecTaskManager {
         this.activeFilter = null;
         this.statuses = ['todo', 'inprogress', 'review', 'done', 'blocked', 'cancelled'];
         this.priorities = ['low', 'medium', 'high', 'critical'];
+        this.samplePushed = false;
         
         this.init();
     }
@@ -50,7 +51,14 @@ class MumatecTaskManager {
                 console.log('Subscribing to Firestore collection:', `users/${window.currentUser.uid}/tasks`);
 
                 this.unsubscribe = onSnapshot(col, (snap) => {
-                    this.tasks = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+                    const tasks = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+                    if (tasks.length === 0 && !this.samplePushed) {
+                        this.samplePushed = true;
+                        this.createSampleTasks();
+                        if (loadingEl) loadingEl.style.display = 'none';
+                        return;
+                    }
+                    this.tasks = tasks;
                     this.updateUI();
                     if (loadingEl) loadingEl.style.display = 'none';
                 }, (error) => {

--- a/signup.html
+++ b/signup.html
@@ -7,8 +7,8 @@
   <link rel="stylesheet" href="styles.css">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <style>
-    body { display: flex; align-items: center; justify-content: center; height: 100vh; }
-    .login-container { width: 320px; padding: 20px; border: 1px solid #ccc; border-radius: 6px; background: #fff; }
+    body { display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; }
+    .login-container { width: 320px; max-width: 95%; padding: 20px; border: 1px solid #ccc; border-radius: 6px; background: #fff; }
     .login-container h2 { text-align: center; margin-bottom: 1rem; }
     .login-container input, .login-container select { width: 100%; padding: 0.5rem; margin-bottom: 1rem; }
     .login-container button { width: 100%; padding: 0.5rem; }


### PR DESCRIPTION
## Summary
- tune login/signup width to fit mobile
- seed sample tasks to Firestore on first load

## Testing
- `node -e "require('./script.js')"` *(fails: ERR_NETWORK_IMPORT_DISALLOWED)*

------
https://chatgpt.com/codex/tasks/task_e_684525a7b960832e8584f6d716deb771