### PR TITLE
Move header links into profile dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,13 +33,8 @@
             <button class="action-btn primary" onclick="todoApp.openAddTaskModal()">
                 <span class="material-icons">add</span> New Task
             </button>
-            <button class="action-btn secondary" id="insightsToggle" aria-label="Open insights" aria-haspopup="dialog">Insights</button>
-            <button class="action-btn secondary" id="themeToggle"><span class="material-icons">dark_mode</span></button>
-            <button class="action-btn secondary" id="profileLink" onclick="window.location.href='profile.html'">Profile</button>
             <button class="action-btn secondary" id="adminLink" style="display:none;" onclick="window.location.href='admin.html'">Admin</button>
             <button class="action-btn secondary" id="orgLink" style="display:none;" onclick="window.location.href='org.html'">Org</button>
-            <button class="action-btn secondary" id="directoryLink" onclick="window.location.href='directory.html'">Directory</button>
-            <button class="action-btn secondary" id="messagesLink" onclick="window.location.href='messages.html'">Messages</button>
             <button class="action-btn secondary" onclick="logout()">Logout</button>
             <div class="view-controls">
                 <button class="view-btn active material-icons" data-view="kanban" aria-label="Kanban view" aria-pressed="true">view_kanban</button>
@@ -62,6 +57,13 @@
                     <div class="user-details">
                         <div class="user-name" id="userName">User</div>
                         <div class="user-role" id="userRole">&nbsp;</div>
+                    </div>
+                    <div class="profile-dropdown" id="profileDropdown">
+                        <a href="profile.html" id="profileLink">Profile</a>
+                        <a href="directory.html" id="directoryLink">Directory</a>
+                        <a href="messages.html" id="messagesLink">Messages</a>
+                        <button id="insightsToggle" class="dropdown-btn" aria-haspopup="dialog">Insights</button>
+                        <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
                     </div>
                 </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -143,6 +143,44 @@ body {
     align-items: center;
     gap: 12px;
     cursor: pointer;
+    position: relative;
+}
+
+.profile-dropdown {
+    display: none;
+    flex-direction: column;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background: var(--background);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius);
+    padding: 8px 0;
+    min-width: 160px;
+    z-index: 1000;
+}
+
+.user-info:hover .profile-dropdown {
+    display: flex;
+}
+
+.profile-dropdown a,
+.profile-dropdown .dropdown-btn {
+    display: block;
+    padding: 8px 16px;
+    font-size: 14px;
+    color: var(--text-primary);
+    text-decoration: none;
+    background: none;
+    border: none;
+    text-align: left;
+    width: 100%;
+    cursor: pointer;
+}
+
+.profile-dropdown a:hover,
+.profile-dropdown .dropdown-btn:hover {
+    background: var(--gray-100);
 }
 
 .user-avatar {


### PR DESCRIPTION
## Summary
- tidy up header by dropping extra buttons
- add new profile dropdown menu in sidebar
- show dropdown on hover with new CSS styles

## Testing
- `npx --yes serve -s -l 5000` *(fails: Checking for updates failed)*

------
https://chatgpt.com/codex/tasks/task_e_6845287b16a0832eb0da888ac82e1e17