### PR TITLE
Fix async logging on user login

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -61,7 +61,7 @@ onAuthStateChanged(auth, async (user) => {
     }
     try {
       const logLogin = httpsCallable(functions, 'logUserLogin');
-      logLogin();
+      await logLogin();
     } catch (e) {
       console.error('Failed to log login', e);
     }


### PR DESCRIPTION
## Summary
- ensure logging user login awaits the cloud function

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68453544ac4c832eb41672e3c61f0465