### PR TITLE
Fix overlapping header on kanban board

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -474,6 +474,9 @@ body {
     display: none;
     height: 100%;
     padding: 24px;
+    /* Ensure content starts below the sticky header */
+    padding-top: calc(var(--top-bar-height) + 24px);
+    box-sizing: border-box;
 }
 
 .view-container.active {


### PR DESCRIPTION
## Summary
- ensure kanban columns start below sticky header

## Testing
- `pre-commit` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_684bea08ec0c832ea83cf729e43bc4de