### PR TITLE
Remove height rule from view container

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -472,7 +472,6 @@ body {
 
 .view-container {
     display: none;
-    height: 100%;
     padding: 24px;
 }
 


### PR DESCRIPTION
## Summary
- avoid forcing `.view-container` to full height so list view spacing is correct

## Testing
- `node inspect.js` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_684c0b70b754832e9440c1787e587e92