### PR TITLE
Dynamic category ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ changes are queued and saved once connectivity returns.
   vertically. Move away from the edge or finish the drag to stop scrolling.
 - Use the arrows in each column or row header to reorder statuses. Your
   preferred order is saved locally and applied on reload.
+- Category links in the sidebar also have up/down arrows. Rearrange them to
+  suit your workflow and the order will persist across sessions.
 
 ### Admin features
 

--- a/index.html
+++ b/index.html
@@ -95,23 +95,9 @@
 
                 <div class="nav-divider"></div>
 
-                <div class="nav-section">
+                <div class="nav-section" id="categoryNavSection">
                     <div class="nav-section-title">Projects</div>
-                    <div class="nav-item" data-filter="Work" aria-label="Work">
-                        <span class="material-icons nav-icon">work</span>
-                        <span class="nav-label">Work</span>
-                        <span class="nav-count" id="workCount">0</span>
-                    </div>
-                    <div class="nav-item" data-filter="Personal" aria-label="Personal">
-                        <span class="material-icons nav-icon">home</span>
-                        <span class="nav-label">Personal</span>
-                        <span class="nav-count" id="personalCount">0</span>
-                    </div>
-                    <div class="nav-item" data-filter="Development" aria-label="Development">
-                        <span class="material-icons nav-icon">code</span>
-                        <span class="nav-label">Development</span>
-                        <span class="nav-count" id="devCount">0</span>
-                    </div>
+                    <div id="categoryNavContainer"></div>
                 </div>
 
                 <div class="nav-divider"></div>

--- a/styles.css
+++ b/styles.css
@@ -274,6 +274,17 @@ body {
     color: white;
 }
 
+.nav-controls {
+    display: flex;
+    gap: 2px;
+    margin-left: auto;
+}
+
+.nav-controls .move-btn {
+    width: 20px;
+    height: 20px;
+}
+
 .nav-divider {
     height: 1px;
     background: var(--border);


### PR DESCRIPTION
## Summary
- build sidebar category items dynamically so they can be reordered
- add UI controls and logic to move categories up or down
- store the order in `localStorage`
- tweak styles for the new controls
- document customizable category order

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684c31e2ec70832eb22a73dcd24b1bc5