### PR TITLE
Update header with tab navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,34 +12,54 @@
     <div id="loadingOverlay" class="loading-overlay" style="display:none;">Loading...</div>
     <!-- Sticky Header -->
     <header class="top-bar" id="mainHeader">
-        <div class="top-bar-left">
-            <button id="sidebarToggle" class="action-btn secondary" aria-label="Toggle navigation menu" aria-expanded="true"><span class="material-icons">menu</span></button>
-            <h1 class="page-title" id="pageTitle">Dashboard</h1>
-
-        </div>
-
-        <div class="top-bar-center">
-            <div class="search-container">
-
-                <input type="text" class="search-input" id="searchInput" placeholder="Search tasks..." aria-label="Search tasks">
-
-                <span class="material-icons search-icon">search</span>
+        <div class="header-row header-primary">
+            <div class="header-left">
+                <button id="sidebarToggle" class="action-btn secondary" aria-label="Toggle navigation menu" aria-expanded="true"><span class="material-icons">menu</span></button>
+                <select id="workspaceSelect" class="workspace-select">
+                    <option>Workspace 1</option>
+                    <option>Workspace 2</option>
+                </select>
+                <div class="breadcrumbs" id="breadcrumbs">
+                    <span id="pageTitle">Dashboard</span>
+                </div>
+            </div>
+            <nav class="tab-nav">
+                <button class="tab-btn active" data-view="kanban">Board</button>
+                <button class="tab-btn" data-view="list">List</button>
+                <button class="tab-btn" data-view="calendar">Calendar</button>
+            </nav>
+            <div class="header-right">
+                <button class="action-btn secondary" id="shareBtn"><span class="material-icons">share</span></button>
+                <div class="filter-badges" id="filterBadges"></div>
+                <select id="groupBySelect" class="group-select">
+                    <option value="">Group by</option>
+                    <option value="status">Status</option>
+                    <option value="assignee">Assignee</option>
+                </select>
             </div>
         </div>
-
-        <div class="top-bar-right">
-            <button class="action-btn secondary" onclick="document.getElementById('csvImport').click()">
-                <span class="material-icons">file_upload</span> Import
-            </button>
-            <button class="action-btn primary" onclick="todoApp.openAddTaskModal()">
-                <span class="material-icons">add</span> New Task
-            </button>
-            <button class="action-btn secondary" id="adminLink" style="display:none;" onclick="window.location.href='admin.html'">Admin</button>
-            <button class="action-btn secondary" id="orgLink" style="display:none;" onclick="window.location.href='org.html'">Org</button>
-            <button class="action-btn secondary" onclick="logout()">Logout</button>
-            <div class="view-controls">
-                <button class="view-btn active material-icons" data-view="kanban" aria-label="Kanban view" aria-pressed="true">view_kanban</button>
-                <button class="view-btn material-icons" data-view="list" aria-label="List view" aria-pressed="false">view_list</button>
+        <div class="header-row header-secondary">
+            <div class="search-wrapper">
+                <div class="search-container">
+                    <input type="text" class="search-input" id="searchInput" placeholder="Search tasks..." aria-label="Search tasks">
+                    <span class="material-icons search-icon">search</span>
+                </div>
+            </div>
+            <div class="team-avatars">
+                <span class="avatar material-icons">person</span>
+                <span class="avatar material-icons">person</span>
+                <span class="avatar material-icons">person</span>
+            </div>
+            <div class="header-actions">
+                <button class="action-btn secondary" onclick="document.getElementById('csvImport').click()">
+                    <span class="material-icons">file_upload</span> Import
+                </button>
+                <button class="action-btn primary" onclick="todoApp.openAddTaskModal()">
+                    <span class="material-icons">add</span> New Task
+                </button>
+                <button class="action-btn secondary" id="adminLink" style="display:none;" onclick="window.location.href='admin.html'">Admin</button>
+                <button class="action-btn secondary" id="orgLink" style="display:none;" onclick="window.location.href='org.html'">Org</button>
+                <button class="action-btn secondary" onclick="logout()">Logout</button>
             </div>
         </div>
     </header>

--- a/script.js
+++ b/script.js
@@ -674,11 +674,11 @@ class MumatecTaskManager {
     }
 
     switchViewMode(mode) {
-        document.querySelectorAll('.view-btn').forEach(btn => {
+        document.querySelectorAll('.tab-btn').forEach(btn => {
             btn.classList.remove('active');
             btn.setAttribute('aria-pressed', 'false');
         });
-        const activeBtn = document.querySelector(`[data-view="${mode}"]`);
+        const activeBtn = document.querySelector(`.tab-btn[data-view="${mode}"]`);
         if (activeBtn) {
             activeBtn.classList.add('active');
             activeBtn.setAttribute('aria-pressed', 'true');
@@ -1004,8 +1004,12 @@ class MumatecTaskManager {
         });
 
         // View mode toggles
-        document.querySelectorAll('.view-btn').forEach(btn => {
+        document.querySelectorAll('.tab-btn').forEach(btn => {
             btn.addEventListener('click', () => {
+                if (btn.dataset.view === 'calendar') {
+                    alert('Calendar view coming soon');
+                    return;
+                }
                 this.switchViewMode(btn.dataset.view);
             });
         });

--- a/styles.css
+++ b/styles.css
@@ -43,7 +43,7 @@
     /* Layout */
     --sidebar-width: 280px;
     --sidebar-transition: transform 0.3s ease, width 0.3s ease;
-    --top-bar-height: 72px;
+    --top-bar-height: 120px;
     --border-radius: 12px;
     --border-radius-sm: 8px;
     --border-radius-lg: 16px;
@@ -328,10 +328,8 @@ body {
     background: var(--background);
     border-bottom: 1px solid var(--border);
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 24px;
-    gap: 24px;
+    flex-direction: column;
+    justify-content: center;
     z-index: 1000;
 }
 
@@ -460,6 +458,99 @@ body {
 .view-btn.active {
     background: var(--background);
     box-shadow: 0 1px 3px var(--shadow);
+}
+
+/* New header layout */
+.header-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 24px;
+    gap: 12px;
+}
+
+.header-primary {
+    height: 56px;
+}
+
+.header-secondary {
+    height: 64px;
+    border-top: 1px solid var(--border);
+}
+
+.header-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.workspace-select {
+    padding: 4px 8px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--surface-secondary);
+}
+
+.breadcrumbs {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 14px;
+    color: var(--text-secondary);
+}
+
+.breadcrumbs span:not(:last-child)::after {
+    content: '\203A';
+    margin-left: 4px;
+}
+
+.tab-nav {
+    display: flex;
+    gap: 12px;
+}
+
+.tab-btn {
+    background: transparent;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.tab-btn.active {
+    color: var(--text-primary);
+    background: var(--surface-secondary);
+}
+
+.team-avatars {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.team-avatars .avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--gray-200);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.search-wrapper {
+    flex: 1;
 }
 
 /* Content Area */
@@ -1430,7 +1521,7 @@ body {
 
 @media (max-width: 768px) {
     :root {
-        --top-bar-height: 60px;
+        --top-bar-height: 100px;
     }
     
     .sidebar {


### PR DESCRIPTION
## Summary
- redesign header with workspace dropdown, breadcrumbs, and tab navigation
- add secondary header row for search and task actions
- support tab-based view switches in JavaScript
- style new header and tabs

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684c3221cf64832e933ebdd291774a97