### PR TITLE
Enable PWA install prompt

### DIFF
--- a/pwa.js
+++ b/pwa.js
@@ -3,3 +3,36 @@ if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('sw.js');
   });
 }
+
+let deferredPrompt;
+
+function showInstallButton() {
+  let btn = document.getElementById('installButton');
+  if (!btn) {
+    btn = document.createElement('button');
+    btn.id = 'installButton';
+    btn.className = 'action-btn secondary';
+    btn.textContent = 'Install';
+    btn.style.display = 'none';
+    document.body.appendChild(btn);
+  }
+  btn.style.display = 'block';
+  btn.addEventListener('click', async () => {
+    btn.style.display = 'none';
+    deferredPrompt.prompt();
+    await deferredPrompt.userChoice;
+    deferredPrompt = null;
+  }, { once: true });
+}
+
+window.addEventListener('beforeinstallprompt', e => {
+  e.preventDefault();
+  deferredPrompt = e;
+  showInstallButton();
+});
+
+window.addEventListener('appinstalled', () => {
+  const btn = document.getElementById('installButton');
+  if (btn) btn.style.display = 'none';
+  deferredPrompt = null;
+});

--- a/styles.css
+++ b/styles.css
@@ -1902,3 +1902,10 @@ body.dark-mode {
   width: 100%;
 }
 
+#installButton {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1000;
+}
+


### PR DESCRIPTION
## Summary
- add beforeinstallprompt handler and floating install button via `pwa.js`
- provide minimal styling for new install button

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c6ffcbd20832e84ea7308e144de4b