### PR TITLE
Implement due date pickers and overdue highlight

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,6 +328,7 @@
                 <button class="close-btn" onclick="todoApp.closeQuickCapture()"><span class="material-icons">close</span></button>
             </div>
             <input type="text" class="quick-input" id="quickTaskInput" placeholder="What needs to be done?">
+            <input type="date" class="quick-input" id="quickTaskDueDate">
             <div class="quick-actions">
                 <button class="quick-btn secondary" onclick="todoApp.closeQuickCapture()">Cancel</button>
                 <button class="quick-btn primary" onclick="todoApp.saveQuickTask()">Add Task</button>

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -553,6 +553,9 @@ class MumatecTaskManager {
 
         const isOverdue = task.dueDate && new Date(task.dueDate) < new Date() && task.status !== 'done';
         const dueText = task.dueDate ? this.formatDate(new Date(task.dueDate)) : '';
+        if (isOverdue) {
+            taskDiv.classList.add('overdue-task');
+        }
         
         const tagsHtml = task.tags && task.tags.length > 0
             ? `<div class="task-tags">${task.tags.map(tag => `<span class="task-tag">${this.escapeHtml(tag)}</span>`).join('')}</div>`
@@ -827,12 +830,14 @@ class MumatecTaskManager {
         modal.classList.add('active');
         modal.setAttribute('aria-hidden', 'false');
         document.getElementById('quickTaskInput').focus();
+        document.getElementById('quickTaskDueDate').value = '';
     }
 
 
     closeQuickCapture() {
         document.getElementById('quickCaptureModal').classList.remove('active');
         document.getElementById('quickTaskInput').value = '';
+        document.getElementById('quickTaskDueDate').value = '';
     }
 
     openInsights() {
@@ -849,9 +854,10 @@ class MumatecTaskManager {
 
     saveQuickTask() {
         const title = document.getElementById('quickTaskInput').value.trim();
+        const dueDate = document.getElementById('quickTaskDueDate').value;
         if (!title) return;
 
-        this.addTask({ title, status: 'todo', category: 'Work', type: 'General' });
+        this.addTask({ title, status: 'todo', category: 'Work', type: 'General', dueDate });
         this.closeQuickCapture();
     }
 

--- a/styles.css
+++ b/styles.css
@@ -864,6 +864,10 @@ body {
     color: white;
 }
 
+.task-card.overdue-task {
+    border-left: 4px solid var(--error-red);
+}
+
 .task-tags {
     display: flex;
     gap: 4px;


### PR DESCRIPTION
## Summary
- allow adding a due date from the Quick Capture modal
- clear due date when closing modal
- store due date from quick capture in tasks
- highlight entire task card when overdue

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c780a67f4832eb78eab50f7a22e06