### PR TITLE
Fix drag and auto-scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ changes are queued and saved once connectivity returns.
 ## Usage Notes
 
 - When dragging a task, keeping the pointer near the viewport edges will
-  automatically scroll the kanban board horizontally or the current view
-  vertically. Move away from the edge or finish the drag to stop scrolling.
+  automatically scroll the kanban board left or right and the page up or down.
+  Move away from the edge or finish the drag to stop scrolling.
 - Use the arrows in each column or row header to reorder statuses. Your
   preferred order is saved locally and applied on reload.
 - Category links in the sidebar also have up/down arrows. Rearrange them to

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,15 +1,17 @@
 export function setupDragAndDrop(manager) {
   document.addEventListener('dragstart', (e) => {
-    if (e.target.classList.contains('task-card')) {
-      manager.draggedTask = e.target.dataset.taskId;
-      e.target.classList.add('dragging');
+    const card = e.target.closest('.task-card');
+    if (card) {
+      manager.draggedTask = card.dataset.taskId;
+      card.classList.add('dragging');
       e.dataTransfer.effectAllowed = 'move';
     }
   });
 
   document.addEventListener('dragend', (e) => {
-    if (e.target.classList.contains('task-card')) {
-      e.target.classList.remove('dragging');
+    const card = e.target.closest('.task-card');
+    if (card) {
+      card.classList.remove('dragging');
       manager.draggedTask = null;
     }
   });
@@ -50,6 +52,8 @@ export function setupDragAndDrop(manager) {
   });
 }
 
+// Automatically scrolls the kanban and list views when dragging near the
+// viewport edges. Works horizontally and vertically.
 export function setupAutoScroll(manager) {
   const threshold = 40;
   let h = 0;
@@ -59,7 +63,7 @@ export function setupAutoScroll(manager) {
 
   const step = () => {
     if (!active) return;
-    const view = document.querySelector('.view-container.active');
+    const view = document.querySelector('.content-area');
     const kanban = document.querySelector('.kanban-container');
     const horizontal = manager.viewMode === 'kanban' ? kanban : rowTarget;
     if (horizontal && h !== 0) {


### PR DESCRIPTION
## Summary
- make drag event handler more robust for child elements
- allow auto-scroll to control the vertically scrollable container
- document updated auto-scroll behavior

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c7bb1d878832e83afc53c6615bae6