### PR TITLE
Fix drag initiation by setting dataTransfer

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -5,6 +5,8 @@ export function setupDragAndDrop(manager) {
       manager.draggedTask = card.dataset.taskId;
       card.classList.add('dragging');
       e.dataTransfer.effectAllowed = 'move';
+      // Some browsers require data to be set for drag to initiate
+      e.dataTransfer.setData('text/plain', card.dataset.taskId);
     }
   });
 


### PR DESCRIPTION
## Summary
- ensure dragstart sets drag data so `drop` works across browsers

## Testing
- `node -c src/ui.js`
- `node -c src/main.js`
- `node -c src/tasks.js`


------
https://chatgpt.com/codex/tasks/task_e_684c7e42bab0832ebc043384cc21eecc