### PR TITLE
Add task time totals and display

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@
                 <div class="nav-section" id="categoryNavSection">
                     <div class="nav-section-title">Projects</div>
                     <div id="categoryNavContainer"></div>
+                    <div id="categoryTimeTotals" class="time-totals"></div>
                 </div>
 
                 <div class="nav-divider"></div>

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -1,7 +1,7 @@
 // Mumatec Task Manager - Professional Application
 import { db, functions } from '../firebase.js';
 import { httpsCallable } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-functions.js';
-import { generateId, escapeHtml as escapeHtmlUtil, parseCSVLine as parseCSVLineUtil, formatDate as formatDateUtil, debounce as debounceUtil } from './utils.js';
+import { generateId, escapeHtml as escapeHtmlUtil, parseCSVLine as parseCSVLineUtil, formatDate as formatDateUtil, debounce as debounceUtil, formatDuration as formatDurationUtil } from './utils.js';
 import { setupDragAndDrop, setupAutoScroll } from './ui.js';
 import { collection, setDoc, doc, deleteDoc, onSnapshot, getDocs, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 class MumatecTaskManager {
@@ -306,8 +306,10 @@ class MumatecTaskManager {
     // UI Management
     updateUI() {
         const stats = this.getTaskStats();
+        const timeTotals = this.computeTimeTotals();
         this.updateStats(stats);
         this.updateNavigationCounts(stats);
+        this.renderCategoryTimeTotals(timeTotals);
         this.updateProductivityRing(stats);
         this.renderCurrentView();
         this.updateInsights();
@@ -368,6 +370,18 @@ class MumatecTaskManager {
                 e.stopPropagation();
                 this.moveCategory(btn.dataset.category, btn.dataset.direction);
             });
+        });
+    }
+
+    renderCategoryTimeTotals(totals = {}) {
+        const container = document.getElementById('categoryTimeTotals');
+        if (!container) return;
+        container.innerHTML = '';
+        this.categoryOrder.forEach(cat => {
+            const total = totals[cat] || 0;
+            const div = document.createElement('div');
+            div.innerHTML = `<span>${escapeHtmlUtil(cat)}</span><span>${formatDurationUtil(total)}</span>`;
+            container.appendChild(div);
         });
     }
 
@@ -589,6 +603,7 @@ class MumatecTaskManager {
                 <span class="timer-indicator" aria-hidden="true"></span>
                 <button class="timer-btn task-start-btn" aria-label="Start timer">Start</button>
                 <button class="timer-btn task-stop-btn" aria-label="Stop timer">Stop</button>
+                <span class="task-time-spent">${formatDurationUtil(task.timeSpent)}</span>
             </div>
         `;
 
@@ -964,6 +979,16 @@ class MumatecTaskManager {
         }
 
         return stats;
+    }
+
+    computeTimeTotals() {
+        const totals = {};
+        for (const t of this.tasks) {
+            const cat = t.category || 'Uncategorized';
+            const spent = parseFloat(t.timeSpent) || 0;
+            totals[cat] = (totals[cat] || 0) + spent;
+        }
+        return totals;
     }
 
     getWeeklyData() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,6 +22,16 @@ export function formatDate(date) {
   return date.toLocaleDateString();
 }
 
+export function formatDuration(hours) {
+  const totalMinutes = Math.round(parseFloat(hours || 0) * 60);
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  if (h > 0) {
+    return `${h}h ${m}m`;
+  }
+  return `${m}m`;
+}
+
 export function debounce(fn, delay = 300) {
   let timeout;
   return (...args) => {

--- a/styles.css
+++ b/styles.css
@@ -292,6 +292,18 @@ body {
     margin: 16px 4px;
 }
 
+.time-totals {
+    padding: 4px 12px 0;
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.time-totals div {
+    display: flex;
+    justify-content: space-between;
+    margin: 2px 0;
+}
+
 /* Sidebar Footer */
 .sidebar-footer {
     padding: 20px;
@@ -921,6 +933,11 @@ body {
     height: 8px;
     border-radius: 50%;
     background: var(--success-green);
+}
+
+.task-time-spent {
+    font-size: 10px;
+    color: var(--text-secondary);
 }
 
 .add-task-card {


### PR DESCRIPTION
## Summary
- show time spent on each task card
- compute totals of time spent per category
- display category time totals in sidebar
- style time display elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d0f7523c4832e94d2e6f2c6baf24a