### PR TITLE
Add subtasks with progress tracking

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -915,6 +915,51 @@ body {
     flex-wrap: wrap;
 }
 
+.subtask-progress {
+    height: 4px;
+    background: var(--gray-200);
+    border-radius: 4px;
+    overflow: hidden;
+    margin-top: 8px;
+}
+
+.subtask-progress-bar {
+    height: 100%;
+    background: var(--success-green);
+}
+
+.subtasks-container {
+    margin-top: 8px;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.subtask-item {
+    font-size: 12px;
+    color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.add-subtask-btn {
+    display: none;
+    position: absolute;
+    top: -4px;
+    right: 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: var(--text-tertiary);
+    font-size: 16px;
+}
+
+.task-card:hover .add-subtask-btn {
+    display: inline-flex;
+}
+
 .task-tag {
     background: var(--surface-secondary);
     color: var(--text-secondary);


### PR DESCRIPTION
## Summary
- support subtasks on each task
- display checklist and progress bar inside task cards
- show `Add Subtask` button on hover

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d14f5362c832e9ae81bff427d5ee2