### PR TITLE
Add label management with search filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,17 @@
 
                 <span class="material-icons search-icon">search</span>
             </div>
+            <div class="label-manager">
+                <button id="labelsToggle" class="action-btn secondary" aria-label="Manage labels"><span class="material-icons">label</span></button>
+                <div class="label-dropdown" id="labelsDropdown">
+                    <div id="labelList"></div>
+                    <div class="label-add">
+                        <input type="text" id="newLabelName" placeholder="Label name">
+                        <input type="color" id="newLabelColor" value="#42a5f5">
+                        <button id="addLabelBtn" class="small-btn">Add</button>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <div class="top-bar-right">
@@ -449,6 +460,11 @@
                     <div class="form-field">
                         <label>Tags</label>
                         <input type="text" id="taskTags" placeholder="urgent, meeting, project">
+                    </div>
+                    <div class="form-field">
+                        <label>Labels</label>
+                        <input type="text" id="taskLabels" list="labelSuggestions" placeholder="Client Work, Urgent">
+                        <datalist id="labelSuggestions"></datalist>
                     </div>
                 </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1440,6 +1440,12 @@ body {
     background: var(--gray-200);
 }
 
+.small-btn {
+    height: 28px;
+    padding: 0 12px;
+    font-size: 12px;
+}
+
 .comments-container {
     display: flex;
     flex-direction: column;
@@ -1794,5 +1800,61 @@ body.dark-mode {
   bottom: 20px;
   right: 20px;
   z-index: 1000;
+}
+
+.label-manager {
+  position: relative;
+  margin-left: 12px;
+}
+
+.label-dropdown {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: var(--border-radius);
+  padding: 8px;
+  min-width: 180px;
+  z-index: 1000;
+}
+
+.label-dropdown.open {
+  display: block;
+}
+
+.label-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+  font-size: 14px;
+}
+
+.label-item .color-box {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+}
+
+.label-add {
+  display: flex;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.task-labels {
+  display: flex;
+  gap: 4px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+
+.task-label {
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10px;
 }
 


### PR DESCRIPTION
## Summary
- implement color-coded label system
- manage labels in new dropdown next to search bar
- show labels on task cards and allow selection in the task modal
- filter tasks by label names using search

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d16d09cb0832e88cd5c9ad9cbd289