### PR TITLE
Add task assignment with avatars

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,8 +416,9 @@
                     <div class="form-row">
                         <div class="form-field">
                             <label>Assignee</label>
-                            <input type="text" id="taskAssignee" list="assigneeSuggestions" placeholder="Assign user">
-                            <datalist id="assigneeSuggestions"></datalist>
+                            <select id="taskAssignee"></select>
+                            <button type="button" id="assignToMeBtn" class="assign-me-btn">Assign to me</button>
+                            <img id="assigneeAvatarPreview" class="task-avatar" style="display:none;margin-top:4px;" alt="Assignee avatar">
                         </div>
                         <div class="form-field">
                             <label>Dependencies</label>

--- a/styles.css
+++ b/styles.css
@@ -1369,6 +1369,22 @@ body {
     background: var(--background);
 }
 
+.assign-me-btn {
+    background: var(--surface-secondary);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius-sm);
+    padding: 4px 8px;
+    font-size: 12px;
+    cursor: pointer;
+    margin-top: 4px;
+    align-self: flex-start;
+    transition: var(--transition);
+}
+
+.assign-me-btn:hover {
+    background: var(--background);
+}
+
 .form-field label {
     font-size: 13px;
     font-weight: 600;


### PR DESCRIPTION
## Summary
- replace assignee text input with dropdown selector
- add "assign to me" quick action and avatar preview
- style assign button
- support dropdown in task manager logic

## Testing
- `node --check src/tasks.js`

------
https://chatgpt.com/codex/tasks/task_e_684d170eb710832e853bba6d86f17ec5