### PR TITLE
Fix login error handling and update service worker cache

### DIFF
--- a/login.js
+++ b/login.js
@@ -9,13 +9,20 @@ document.getElementById('loginForm').addEventListener('submit', async (e) => {
   const password = document.getElementById('password').value;
   const errorEl = document.getElementById('error');
   errorEl.textContent = '';
+  const messages = {
+    'auth/invalid-email': 'Invalid email address.',
+    'auth/user-disabled': 'Account disabled.',
+    'auth/user-not-found': 'No account found for this email.',
+    'auth/wrong-password': 'Incorrect password.',
+    'auth/network-request-failed': 'Network error. Check your connection.'
+  };
   try {
     await signInWithEmailAndPassword(auth, email, password);
 
     window.location.href = 'index.html';
 
   } catch (err) {
-    errorEl.textContent = err.message;
+    errorEl.textContent = messages[err.code] || err.message;
   }
 });
 

--- a/sw.js
+++ b/sw.js
@@ -4,8 +4,10 @@ const ASSETS = [
   './index.html',
   './admin.html',
   './login.html',
+  './login.js',
   './client-portal.html',
   './admin.js',
+  './auth.js',
   './firebase.js',
   './pwa.js',
   './manifest.json',
@@ -31,15 +33,12 @@ self.addEventListener('activate', event => {
 self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') return;
   event.respondWith(
-    caches.match(event.request).then(cached => {
-      const fetchPromise = fetch(event.request)
-        .then(response => {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
-          return response;
-        })
-        .catch(() => cached);
-      return cached || fetchPromise;
-    })
+    fetch(event.request)
+      .then(response => {
+        const clone = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+        return response;
+      })
+      .catch(() => caches.match(event.request))
   );
 });


### PR DESCRIPTION
## Summary
- cache login.js and auth.js for PWA
- switch service worker to network-first strategy
- provide friendlier login error messages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d29ac5240832e8b9c02505a0954d8