### PR TITLE
Fix missing priority comparator

### DIFF
--- a/src/tasks.js
+++ b/src/tasks.js
@@ -429,6 +429,11 @@ class MumatecTaskManager {
         return labelsString.split(',').map(l => l.trim()).filter(l => l);
     }
 
+    comparePriority(a, b) {
+        const rank = { critical: 0, high: 1, medium: 2, low: 3 };
+        return (rank[a.priority] ?? 4) - (rank[b.priority] ?? 4);
+    }
+
     // UI Management
 
     updateUI() {


### PR DESCRIPTION
## Summary
- provide a `comparePriority` method so tasks can be sorted by priority

## Testing
- `npm run dev` *(fails: serve missing -> install, then it runs)*

------
https://chatgpt.com/codex/tasks/task_e_68566db55210832ebb1bcb180f2b1e1f