### PR TITLE
Add glossy theme with style switcher

### DIFF
--- a/glossy.css
+++ b/glossy.css
@@ -1,0 +1,37 @@
+@import url('styles.css');
+
+:root {
+  --background: linear-gradient(135deg, #0e5077 0%, #06315e 100%);
+  --surface: rgba(255,255,255,0.05);
+  --surface-secondary: rgba(255,255,255,0.08);
+  --text-primary: #ffffff;
+  --text-secondary: #a2b1bd;
+  --border: rgba(255,255,255,0.1);
+  --primary-blue: #24a1c6;
+  --primary-blue-hover: #1d90b6;
+  --shadow: rgba(0,0,0,0.3);
+}
+
+body {
+  background: var(--background);
+  color: var(--text-primary);
+}
+
+.sidebar, .auth-container, .modal-overlay .quick-capture-modal,
+.modal-overlay .insights-modal, .modal-overlay .modal-content,
+.app-container, .content-area, .stat-card, .task-card {
+  background: var(--surface);
+  backdrop-filter: blur(20px);
+  border: 1px solid var(--border);
+  box-shadow: 0 8px 32px var(--shadow);
+}
+
+.css-glass-card {
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}

--- a/index.html
+++ b/index.html
@@ -4,11 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mumatec Tasking</title>
-    <link rel="stylesheet" href="styles.css">
+    <link id="styleLink" rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <script src="check-environment.js"></script>
+    <script src="style.js"></script>
+    <script>loadPreferredStyle();</script>
 </head>
 <body>
     <div id="loadingOverlay" class="loading-overlay" style="display:none;">Loading...</div>
@@ -62,6 +64,7 @@
                     </div>
                     <div class="profile-dropdown" id="profileDropdown" style="display:none;">
                         <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                        <button id="styleToggle" class="dropdown-btn" onclick="toggleStyleSheet()">Glossy Style</button>
                     </div>
                 </div>
             </div>

--- a/login.html
+++ b/login.html
@@ -4,11 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login - Mumatec Tasking</title>
-  <link rel="stylesheet" href="styles.css">
+  <link id="styleLink" rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="check-environment.js"></script>
+  <script src="style.js"></script>
+  <script>loadPreferredStyle();</script>
 </head>
 <body class="auth-page">
   <div class="auth-container">

--- a/reset.html
+++ b/reset.html
@@ -4,10 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Reset Password - Mumatec Tasking</title>
-  <link rel="stylesheet" href="styles.css">
+  <link id="styleLink" rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="style.js"></script>
+  <script>loadPreferredStyle();</script>
 </head>
 <body class="auth-page">
   <div class="auth-container">

--- a/signup.html
+++ b/signup.html
@@ -4,10 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sign Up - Mumatec Tasking</title>
-  <link rel="stylesheet" href="styles.css">
+  <link id="styleLink" rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="style.js"></script>
+  <script>loadPreferredStyle();</script>
 </head>
 <body class="auth-page">
   <div class="auth-container">

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -60,6 +60,7 @@ class MumatecTaskManager {
         await this.loadTaskTypes();
         await this.loadUsers();
         this.loadLabels();
+        this.loadStyleSheet();
         this.loadTheme();
         this.loadSidebarState();
         this.loadStatusOrder();
@@ -1393,6 +1394,13 @@ class MumatecTaskManager {
             this.toggleTheme();
         });
 
+        const styleBtn = document.getElementById('styleToggle');
+        if (styleBtn) {
+            styleBtn.addEventListener('click', () => {
+                this.toggleStyleSheet();
+            });
+        }
+
         const labelsToggle = document.getElementById('labelsToggle');
         const labelsDropdown = document.getElementById('labelsDropdown');
         if (labelsToggle && labelsDropdown) {
@@ -1870,6 +1878,19 @@ class MumatecTaskManager {
         const isDark = document.body.classList.toggle('dark-mode');
         localStorage.setItem('mumatecTheme', isDark ? 'dark' : 'light');
         this.updateThemeToggleIcon();
+    }
+
+    // Style sheet management
+    loadStyleSheet() {
+        if (typeof loadPreferredStyle === 'function') {
+            loadPreferredStyle();
+        }
+    }
+
+    toggleStyleSheet() {
+        if (typeof toggleStyleSheet === 'function') {
+            toggleStyleSheet();
+        }
     }
 
     updateThemeToggleIcon() {

--- a/style.js
+++ b/style.js
@@ -1,0 +1,26 @@
+(function(){
+  window.loadPreferredStyle = function(){
+    const pref = localStorage.getItem('mumatecStyle');
+    const link = document.getElementById('styleLink');
+    if(!link) return;
+    link.setAttribute('href', pref === 'new' ? 'glossy.css' : 'styles.css');
+    updateStyleToggle();
+  };
+
+  window.toggleStyleSheet = function(){
+    const link = document.getElementById('styleLink');
+    if(!link) return;
+    const usingNew = link.getAttribute('href') === 'glossy.css';
+    link.setAttribute('href', usingNew ? 'styles.css' : 'glossy.css');
+    localStorage.setItem('mumatecStyle', usingNew ? 'old' : 'new');
+    updateStyleToggle();
+  };
+
+  function updateStyleToggle(){
+    const btn = document.getElementById('styleToggle');
+    if(btn){
+      const pref = localStorage.getItem('mumatecStyle') === 'new';
+      btn.textContent = pref ? 'Classic Style' : 'Glossy Style';
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- add **glossy.css** with glassmorphism-inspired palette
- create **style.js** to load or toggle between classic and glossy stylesheets
- update HTML pages to use the style loader and provide a toggle button in the dashboard
- hook new style functions into the task manager

## Testing
- `npm test` *(fails: Missing script)*
- `npm run dev` *(fails: `serve` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685676313e00832e8ede333a2a127bd6