### PR TITLE
Fix runtime glossy style toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
                         <div class="user-name" id="userName">User</div>
                         <div class="user-role" id="userRole">&nbsp;</div>
                     </div>
-                    <div class="profile-dropdown" id="profileDropdown" style="display:none;">
+                    <div class="profile-dropdown" id="profileDropdown">
                         <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
                         <button id="styleToggle" class="dropdown-btn" onclick="toggleStyleSheet()">Glossy Style</button>
                     </div>

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -1401,6 +1401,20 @@ class MumatecTaskManager {
             });
         }
 
+        const userInfo = document.getElementById('userInfo');
+        const profileDropdown = document.getElementById('profileDropdown');
+        if (userInfo && profileDropdown) {
+            userInfo.addEventListener('click', (e) => {
+                e.stopPropagation();
+                profileDropdown.classList.toggle('open');
+            });
+            document.addEventListener('click', (e) => {
+                if (!profileDropdown.contains(e.target) && e.target !== userInfo && !userInfo.contains(e.target)) {
+                    profileDropdown.classList.remove('open');
+                }
+            });
+        }
+
         const labelsToggle = document.getElementById('labelsToggle');
         const labelsDropdown = document.getElementById('labelsDropdown');
         if (labelsToggle && labelsDropdown) {

--- a/styles.css
+++ b/styles.css
@@ -161,6 +161,10 @@ body {
     z-index: 1000;
 }
 
+.profile-dropdown.open {
+    display: flex;
+}
+
 .user-info:hover .profile-dropdown {
     display: flex;
 }


### PR DESCRIPTION
## Summary
- expose the profile dropdown in the sidebar
- allow tapping user info to open the dropdown
- handle closing dropdown when clicking outside
- support dropdown open state in CSS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685678a1a4c4832ebb74487775a3a6d8