### PR TITLE
Fix theme toggle persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <script src="check-environment.js"></script>
     <script src="style.js"></script>
-    <script>loadPreferredStyle();</script>
+    <script>loadPreferredStyle(); applySavedTheme();</script>
 </head>
 <body>
     <div id="loadingOverlay" class="loading-overlay" style="display:none;">Loading...</div>

--- a/login.html
+++ b/login.html
@@ -10,7 +10,7 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="check-environment.js"></script>
   <script src="style.js"></script>
-  <script>loadPreferredStyle();</script>
+  <script>loadPreferredStyle(); applySavedTheme();</script>
 </head>
 <body class="auth-page">
   <div class="auth-container">

--- a/reset.html
+++ b/reset.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>loadPreferredStyle();</script>
+  <script>loadPreferredStyle(); applySavedTheme();</script>
 </head>
 <body class="auth-page">
   <div class="auth-container">

--- a/signup.html
+++ b/signup.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>loadPreferredStyle();</script>
+  <script>loadPreferredStyle(); applySavedTheme();</script>
 </head>
 <body class="auth-page">
   <div class="auth-container">

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -1881,16 +1881,24 @@ class MumatecTaskManager {
 
     // Theme Management
     loadTheme() {
-        const saved = localStorage.getItem('mumatecTheme');
-        if (saved === 'dark') {
-            document.body.classList.add('dark-mode');
+        if (typeof window.applySavedTheme === 'function') {
+            window.applySavedTheme();
+        } else {
+            const saved = localStorage.getItem('mumatecTheme');
+            if (saved === 'dark') {
+                document.body.classList.add('dark-mode');
+            }
         }
         this.updateThemeToggleIcon();
     }
 
     toggleTheme() {
-        const isDark = document.body.classList.toggle('dark-mode');
-        localStorage.setItem('mumatecTheme', isDark ? 'dark' : 'light');
+        if (typeof window.toggleThemePreference === 'function') {
+            window.toggleThemePreference();
+        } else {
+            const isDark = document.body.classList.toggle('dark-mode');
+            localStorage.setItem('mumatecTheme', isDark ? 'dark' : 'light');
+        }
         this.updateThemeToggleIcon();
     }
 

--- a/style.js
+++ b/style.js
@@ -23,4 +23,24 @@
       btn.textContent = pref ? 'Classic Style' : 'Glossy Style';
     }
   }
+
+  function updateThemeIcon(){
+    const btn = document.getElementById('themeToggle');
+    if(btn){
+      btn.innerHTML = `<span class="material-icons">${document.body.classList.contains('dark-mode') ? 'light_mode' : 'dark_mode'}</span>`;
+    }
+  }
+
+  window.applySavedTheme = function(){
+    if(localStorage.getItem('mumatecTheme') === 'dark'){
+      document.body.classList.add('dark-mode');
+    }
+    updateThemeIcon();
+  };
+
+  window.toggleThemePreference = function(){
+    const isDark = document.body.classList.toggle('dark-mode');
+    localStorage.setItem('mumatecTheme', isDark ? 'dark' : 'light');
+    updateThemeIcon();
+  };
 })();


### PR DESCRIPTION
## Summary
- make theme preference available on all pages
- initialize dark mode earlier via `applySavedTheme`
- delegate theme actions in `tasks.js` to shared functions

## Testing
- `npm run dev` *(fails: serve not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569344c274832e932c977ab2543035