### PR TITLE
Add project support and dynamic task modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Simple task manager app with Firebase authentication and Firestore storage.
 
+The task modal now includes a **Project** selector. Projects can be created on
+the fly and may define a type (e.g. *software* or *marketing*) which controls
+which fields are shown when creating issues.
+
 The account **mumatechosting@gmail.com** is considered the super administrator
 and always has full rights to manage other users.
 

--- a/index.html
+++ b/index.html
@@ -362,6 +362,14 @@
                         <input type="text" id="taskTitle" required>
                     </div>
 
+                    <div class="form-field">
+                        <label>Project</label>
+                        <div class="project-select">
+                            <select id="taskProject"></select>
+                            <button type="button" id="newProjectBtn" class="new-project-btn">+</button>
+                        </div>
+                    </div>
+
                     <div class="form-row">
                         <div class="form-field">
                             <label>Priority</label>
@@ -404,11 +412,11 @@
                                 <button type="button" class="date-shortcut-btn" data-shortcut="end-month">End of Month</button>
                             </div>
                         </div>
-                        <div class="form-field">
+                        <div class="form-field" id="taskCategoryField">
                             <label>Category</label>
                             <input type="text" id="taskCategory" placeholder="e.g., Work, Personal">
                         </div>
-                        <div class="form-field">
+                        <div class="form-field" id="taskTypeField">
                             <label>Type</label>
                             <input type="text" id="taskType" list="typeSuggestions" placeholder="e.g., Bug">
                             <datalist id="typeSuggestions"></datalist>

--- a/styles.css
+++ b/styles.css
@@ -1434,6 +1434,27 @@ body {
     background: var(--background);
 }
 
+.project-select {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.new-project-btn {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: 1px solid var(--border);
+    background: var(--surface-secondary);
+    border-radius: var(--border-radius-sm);
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.new-project-btn:hover {
+    background: var(--background);
+}
+
 .form-field label {
     font-size: 13px;
     font-weight: 600;


### PR DESCRIPTION
## Summary
- introduce project selector with the ability to add new projects
- show or hide fields depending on selected project type
- persist project selection on tasks and reset appropriately
- minor CSS for new controls
- document project selector in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run dev` *(fails: serve not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569ff881c0832e821e2713e75a6103