### PR TITLE
Enhance task comments

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -96,7 +96,7 @@ Fields are normalised in code and may include:
 - **estimate**: number *(optional)*
 - **timeSpent**: number *(optional)*
 - **attachments**: array *(optional)*
-- **comments**: array *(optional)*
+- **comments**: array *(optional)* – each item `{ text, author, userId, timestamp, reactions }`
 - **tags**: array *(optional)*
 - **labels**: array *(optional)*
 - **subtasks**: array *(optional)*

--- a/index.html
+++ b/index.html
@@ -450,11 +450,6 @@
                 </div>
 
                 <div class="form-section">
-                    <div id="commentsContainer" class="comments-container"></div>
-                    <div class="form-field">
-                        <label>Add Comment</label>
-                        <textarea id="taskComment" rows="2" placeholder="Add a comment"></textarea>
-                    </div>
                     <div class="form-field">
                         <label>Notes</label>
                         <textarea id="taskNotes" rows="2" placeholder="Internal notes"></textarea>
@@ -468,6 +463,11 @@
                         <label>Labels</label>
                         <input type="text" id="taskLabels" list="labelSuggestions" placeholder="Client Work, Urgent">
                         <datalist id="labelSuggestions"></datalist>
+                    </div>
+                    <div id="commentsContainer" class="comments-container"></div>
+                    <div class="form-field">
+                        <label>Add Comment</label>
+                        <textarea id="taskComment" rows="2" placeholder="Add a comment"></textarea>
                     </div>
                 </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1589,6 +1589,26 @@ body {
     margin-bottom: 4px;
 }
 
+.comment-reactions {
+    margin-top: 4px;
+    display: flex;
+    gap: 4px;
+}
+
+.emoji-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    color: var(--text-secondary);
+}
+.emoji-btn span {
+    font-size: 12px;
+}
+
 .task-avatar {
     width: 24px;
     height: 24px;


### PR DESCRIPTION
## Summary
- reorder task modal so comments are last
- allow emoji reactions on comments
- render comment reactions and counts
- document comment schema with reaction info

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68570d35a330832ebcab968f34a95050