### PR TITLE
Remove progress and notes from sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,27 +114,7 @@
                 </div>
             </div>
 
-                <div class="sidebar-footer">
-                <div class="productivity-ring">
-                    <svg class="ring-progress" width="60" height="60">
-                        <circle cx="30" cy="30" r="25" fill="none" stroke="#f0f0f0" stroke-width="4"/>
-                        <circle cx="30" cy="30" r="25" fill="none" stroke="#007AFF" stroke-width="4"
-                                stroke-dasharray="157" stroke-dashoffset="157"
-                                transform="rotate(-90 30 30)" id="progressRing"/>
-                    </svg>
-                    <div class="ring-content">
-                        <span id="productivityPercent">0%</span>
-                    </div>
-                </div>
-                <div class="productivity-text">Today's Progress</div>
-                <div class="weekly-time">
-                    <span id="weeklyHours">0h</span> this week
-                    <button id="weeklyInsightsLink" class="insights-link" aria-haspopup="dialog"><span class="material-icons" style="font-size:16px;vertical-align:middle;">insights</span></button>
-                </div>
-                <div class="quick-notes">
-                    <textarea id="quickNotes" placeholder="Quick notes..."></textarea>
-                </div>
-            </div>
+                <!-- Sidebar footer removed -->
         </div>
 
         <!-- Main Content -->

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -589,14 +589,16 @@ class MumatecTaskManager {
     }
 
     updateProductivityRing(stats) {
-        const percentage = stats.total > 0 ? Math.round((stats.completed / stats.total) * 100) : 0;
-        
         const ring = document.getElementById('progressRing');
+        const percentEl = document.getElementById('productivityPercent');
+        if (!ring || !percentEl) return;
+
+        const percentage = stats.total > 0 ? Math.round((stats.completed / stats.total) * 100) : 0;
         const circumference = 2 * Math.PI * 25; // radius = 25
         const offset = circumference - (percentage / 100) * circumference;
-        
+
         ring.style.strokeDashoffset = offset;
-        document.getElementById('productivityPercent').textContent = `${percentage}%`;
+        percentEl.textContent = `${percentage}%`;
     }
 
     renderCurrentView() {


### PR DESCRIPTION
## Summary
- remove the sidebar footer with Today's Progress and Quick Notes
- guard against missing progress ring in JS

## Testing
- `node check-environment.js` *(fails: ReferenceError: location is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68570e935990832e84d0b43fb76ce8c3