### PR TITLE
Refine task modal structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -438,23 +438,23 @@
                             <label>Est. Hours</label>
                             <input type="number" id="taskEstimate" min="0" step="0.1">
                         </div>
-                        <div class="form-field">
+                        <div class="form-field edit-only">
                             <label>Time Spent</label>
                             <input type="number" id="taskTimeSpent" min="0" step="0.1">
                         </div>
                     </div>
-                    <div class="form-field">
+                    <div class="form-field edit-only">
                         <label>Attachments</label>
                         <input type="file" id="taskAttachments" multiple>
                     </div>
                 </div>
 
                 <div class="form-section">
-                    <div class="form-field">
+                    <div class="form-field edit-only">
                         <label>Notes</label>
                         <textarea id="taskNotes" rows="2" placeholder="Internal notes"></textarea>
                     </div>
-                    <div class="activity-feed" id="activityFeed"></div>
+                    <div class="activity-feed edit-only" id="activityFeed"></div>
                     <div class="form-field">
                         <label>Tags</label>
                         <input type="text" id="taskTags" placeholder="urgent, meeting, project">
@@ -464,8 +464,8 @@
                         <input type="text" id="taskLabels" list="labelSuggestions" placeholder="Client Work, Urgent">
                         <datalist id="labelSuggestions"></datalist>
                     </div>
-                    <div id="commentsContainer" class="comments-container"></div>
-                    <div class="form-field">
+                    <div id="commentsContainer" class="comments-container edit-only"></div>
+                    <div class="form-field edit-only">
                         <label>Add Comment</label>
                         <textarea id="taskComment" rows="2" placeholder="Add a comment"></textarea>
                     </div>

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -1061,10 +1061,23 @@ class MumatecTaskManager {
         }
     }
 
+    toggleEditFields(isEdit) {
+        const modal = document.getElementById('taskModal');
+        if (!modal) return;
+        if (isEdit) {
+            modal.classList.add('edit-mode');
+            modal.classList.remove('add-mode');
+        } else {
+            modal.classList.remove('edit-mode');
+            modal.classList.add('add-mode');
+        }
+    }
+
     // Modal Management
     openAddTaskModal(status = 'todo') {
         this.currentEditingTask = null;
         document.getElementById('modalTitle').textContent = 'Add New Task';
+        this.toggleEditFields(false);
         this.clearTaskForm();
         document.getElementById('taskStatus').value = status;
         const projectSelect = document.getElementById('taskProject');
@@ -1086,6 +1099,7 @@ class MumatecTaskManager {
 
         this.currentEditingTask = taskId;
         document.getElementById('modalTitle').textContent = 'Edit Task';
+        this.toggleEditFields(true);
         
         document.getElementById('taskTitle').value = task.title;
         document.getElementById('taskDescription').value = task.description || '';
@@ -1135,6 +1149,7 @@ class MumatecTaskManager {
         const modal = document.getElementById('taskModal');
         modal.classList.remove('active');
         modal.setAttribute('aria-hidden', 'true');
+        modal.classList.remove('edit-mode', 'add-mode');
         this.clearTaskForm();
         this.currentEditingTask = null;
     }

--- a/styles.css
+++ b/styles.css
@@ -1997,3 +1997,15 @@ body.dark-mode {
 
 }
 
+/* Visibility handling for add/edit task modal */
+.edit-only {
+  display: none;
+}
+
+#taskModal.edit-mode .edit-only {
+  display: flex;
+}
+#taskModal.edit-mode .activity-feed.edit-only {
+  display: block;
+}
+


### PR DESCRIPTION
## Summary
- hide comment fields and other edit-only inputs when creating a new task
- add CSS rules to toggle visibility of edit-only sections
- switch modal classes when opening add or edit task windows

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68571215b5d8832eb2fc07af56216a1c