### PR TITLE
Add user management page

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,9 @@
                     <button class="dropdown-btn" onclick="document.getElementById('csvImport').click()">
                         <span class="material-icons">file_upload</span> Import
                     </button>
+                    <a href="user-management.html" class="dropdown-btn">
+                        <span class="material-icons">manage_accounts</span> User Management
+                    </a>
                     <button class="dropdown-btn" onclick="logout()">Logout</button>
                 </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -1945,6 +1945,18 @@ body.dark-mode {
   width: 100%;
 }
 
+/* User management table */
+.user-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.user-table th,
+.user-table td {
+  padding: 8px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
 #installButton {
   position: fixed;
   bottom: 20px;

--- a/user-management.html
+++ b/user-management.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>User Management - Mumatec Tasking</title>
+  <link id="styleLink" rel="stylesheet" href="styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="style.js"></script>
+  <script>applySavedTheme();</script>
+</head>
+<body>
+  <header class="top-bar">
+    <div class="top-bar-left">
+      <a href="index.html" class="action-btn secondary" aria-label="Back to dashboard"><span class="material-icons">arrow_back</span></a>
+      <h1 class="page-title">User Management</h1>
+    </div>
+    <div class="top-bar-right">
+      <div class="user-info" id="userInfo">
+        <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
+        <div class="profile-dropdown" id="profileDropdown">
+          <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+          <button class="dropdown-btn" onclick="logout()">Logout</button>
+        </div>
+      </div>
+    </div>
+  </header>
+  <div class="app-container" style="padding:20px;">
+    <table class="user-table">
+      <thead>
+        <tr><th>Name</th><th>Email</th></tr>
+      </thead>
+      <tbody id="userTableBody"></tbody>
+    </table>
+  </div>
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="auth.js"></script>
+  <script type="module" src="user-management.js"></script>
+</body>
+</html>

--- a/user-management.js
+++ b/user-management.js
@@ -1,0 +1,30 @@
+import { auth, db } from './firebase.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
+import { collection, getDocs } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+
+const tbody = document.getElementById('userTableBody');
+
+async function loadUsers() {
+  if (!db) return;
+  try {
+    const snap = await getDocs(collection(db, 'users'));
+    tbody.innerHTML = '';
+    snap.forEach(doc => {
+      const data = doc.data();
+      const tr = document.createElement('tr');
+      const name = data.displayName || data.name || '';
+      tr.innerHTML = `<td>${name}</td><td>${data.email || ''}</td>`;
+      tbody.appendChild(tr);
+    });
+  } catch (e) {
+    console.error('Failed to load users', e);
+  }
+}
+
+onAuthStateChanged(auth, user => {
+  if (!user) {
+    window.location.href = 'login.html';
+  } else {
+    loadUsers();
+  }
+});


### PR DESCRIPTION
## Summary
- link new **User Management** page from profile dropdown
- create `user-management.html` page to display user accounts
- add basic user list functionality in `user-management.js`
- style the users table in `styles.css`

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6857175bd06c832ea70cc1268862909d