### PR TITLE
Add additional task collections and design doc

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -79,6 +79,63 @@ Used for admin notifications.
 - **message**: string *(optional)*
 - other arbitrary fields
 
+## tasks (collection)
+Top-level storage for tasks. Each document mirrors the fields listed in the
+[Tasks subcollection](#tasks-subcollection) and may be referenced from other
+collections.
+
+## taskComments (collection)
+Stores threaded comments for tasks.
+- **taskId**: string
+- **authorId**: string
+- **text**: string
+- **createdAt**: timestamp
+- **updatedAt**: timestamp *(optional)*
+- **internal**: boolean *(optional)*
+- **reactions**: map *(optional)*
+
+## taskActivity (collection)
+Historical activity records for tasks.
+- **taskId**: string
+- **action**: string
+- **actorId**: string *(optional)*
+- **timestamp**: timestamp
+- **extra**: object *(optional)*
+
+## taskAttachments (collection)
+Metadata for files attached to tasks.
+- **taskId**: string
+- **name**: string
+- **size**: number
+- **contentType**: string
+- **url**: string
+- **uploadedBy**: uid
+- **createdAt**: timestamp
+
+## timeLogs (collection)
+Time tracking entries.
+- **taskId**: string
+- **userId**: string
+- **minutes**: number
+- **description**: string *(optional)*
+- **billable**: boolean *(optional)*
+- **createdAt**: timestamp
+
+## taskRelations (collection)
+Defines dependencies and relationships between tasks.
+- **taskId**: string
+- **relatedTaskId**: string
+- **type**: `blocks` | `blockedBy` | `relatesTo` | `subtask`
+- **createdAt**: timestamp
+
+## notifications (collection)
+User notifications and watch records.
+- **taskId**: string *(optional)*
+- **recipientId**: string
+- **type**: string
+- **read**: boolean
+- **createdAt**: timestamp
+
 ## Tasks subcollection
 Each user document has a `tasks` subcollection.
 Fields are normalised in code and may include:

--- a/EDIT_TASK_MODAL_DESIGN.md
+++ b/EDIT_TASK_MODAL_DESIGN.md
@@ -1,0 +1,36 @@
+# Edit Task Modal Design Overview
+
+This document captures the intended feature set for the new Edit Task modal.
+It is based on the comprehensive project requirements.
+
+## Tabbed Interface
+- **Details Tab** – Core fields including status, estimate, time spent and notes.
+- **Comments Tab** – Threaded comments with avatars, emoji reactions and drafts.
+- **Activity Tab** – Chronological history of all task actions.
+- **Attachments Tab** – Upload area with drag & drop and file previews.
+
+Keyboard shortcuts (Ctrl+1..Ctrl+4) switch between tabs. The last active tab is
+remembered per user session.
+
+## Real‑Time Collaboration
+- Presence indicators when other users are viewing or typing.
+- Auto‑refresh of comments and activity streams.
+- Conflict resolution when multiple edits occur simultaneously.
+
+## Task Relationships
+- Visualise dependencies, subtasks and related issues.
+- Ability to create or unlink relations from within the modal.
+
+## Time Tracking
+- Start/stop timer widget to log work.
+- Summary of estimated versus actual effort with billable flag.
+
+## Notifications
+- Users can watch/unwatch a task for updates.
+- @mentions trigger notifications.
+
+## Responsive Behaviour
+The modal adapts to small screens using collapsible tabs and swipe gestures.
+
+This design assumes the additional Firestore collections outlined in
+`DATABASE_SCHEMA.md` are available.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ and always has full rights to manage other users.
 
 1. Install dependencies with `npm install`.
 2. Initialize Firestore collections with `npm run init:collections` (requires a
-   Firebase service account key).
+   Firebase service account key). The script now provisions additional
+   collections for comments, activity logs, attachments, and time tracking.
 3. Start the dev server using `npm run dev` (uses `serve` under the hood).
 4. Visit `login.html` to sign in with your admin credentials.
 5. If you do not have an account, use `signup.html` which will create a client

--- a/initFirestoreCollections.js
+++ b/initFirestoreCollections.js
@@ -14,6 +14,8 @@ if (fs.existsSync(credentialsPath)) {
 
 const db = getFirestore(app);
 
+// Base collections used throughout the app. Additional collections for the
+// advanced task features are appended below.
 const collections = [
   'users',
   'settings',
@@ -24,7 +26,15 @@ const collections = [
   'invoices',
   'apiKeys',
   'rateLimits',
-  'userRequests'
+  'userRequests',
+  // Task management
+  'tasks',
+  'taskComments',
+  'taskActivity',
+  'taskAttachments',
+  'timeLogs',
+  'taskRelations',
+  'notifications'
 ];
 
 async function ensureCollection(col) {


### PR DESCRIPTION
## Summary
- extend Firestore init script with collections for tasks, comments, activity, attachments, time logs, relations and notifications
- document new collections in `DATABASE_SCHEMA.md`
- note new collections in `README.md`
- provide an initial design overview for the Edit Task modal

## Testing
- `npm run init:collections` *(fails: Cannot find module 'firebase-admin/app')*

------
https://chatgpt.com/codex/tasks/task_e_68571cf538e4832e8a36559359e2150c