### PR TITLE
Implement user management layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1997,6 +1997,38 @@ body.dark-mode {
   border-bottom: 1px solid var(--border);
 }
 
+.avatar-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.table-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.user-actions {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.user-stats {
+  display: flex;
+  gap: 12px;
+  margin: 12px 0;
+}
+
+.action-btn.small {
+  height: 28px;
+  padding: 0 12px;
+  font-size: 12px;
+  border-radius: 14px;
+}
+
 #installButton {
   position: fixed;
   bottom: 20px;

--- a/user-management.html
+++ b/user-management.html
@@ -27,16 +27,81 @@
       </div>
     </div>
   </header>
-  <div class="app-container" style="padding:20px;">
-    <table class="user-table">
-      <thead>
-        <tr><th>Name</th><th>Email</th></tr>
-      </thead>
-      <tbody id="userTableBody"></tbody>
-    </table>
+
+  <div class="app-container">
+    <div class="sidebar">
+      <div class="sidebar-nav">
+        <div class="nav-item active" aria-label="All Users">
+          <span class="material-icons nav-icon">people</span>
+          <span class="nav-label">All Users</span>
+        </div>
+        <div class="nav-item" aria-label="User Roles &amp; Permissions">
+          <span class="material-icons nav-icon">security</span>
+          <span class="nav-label">User Roles &amp; Permissions</span>
+        </div>
+        <div class="nav-item" aria-label="Departments/Teams">
+          <span class="material-icons nav-icon">groups</span>
+          <span class="nav-label">Departments/Teams</span>
+        </div>
+        <div class="nav-item" aria-label="Inactive Users">
+          <span class="material-icons nav-icon">person_off</span>
+          <span class="nav-label">Inactive Users</span>
+        </div>
+        <div class="nav-item" aria-label="Pending Invitations">
+          <span class="material-icons nav-icon">mail</span>
+          <span class="nav-label">Pending Invitations</span>
+        </div>
+        <div class="nav-item" aria-label="Audit Logs">
+          <span class="material-icons nav-icon">list_alt</span>
+          <span class="nav-label">Audit Logs</span>
+        </div>
+        <div class="nav-item" aria-label="Bulk Actions">
+          <span class="material-icons nav-icon">playlist_add_check</span>
+          <span class="nav-label">Bulk Actions</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="main-content">
+      <div class="content-area" style="padding:20px;">
+        <div class="user-actions">
+          <button class="action-btn primary" id="inviteBtn"><span class="material-icons">person_add</span> Invite</button>
+          <button class="action-btn secondary" id="bulkEditBtn"><span class="material-icons">edit</span> Bulk Edit</button>
+          <button class="action-btn secondary" id="exportBtn"><span class="material-icons">download</span> Export</button>
+        </div>
+
+        <div class="user-filters">
+          <input type="text" id="userSearch" class="search-input" placeholder="Search users...">
+        </div>
+
+        <div class="user-stats">
+          <div class="stat-card"><div class="stat-number" id="totalUsers">0</div><div class="stat-label">Total Users</div></div>
+          <div class="stat-card"><div class="stat-number" id="activeUsers">0</div><div class="stat-label">Active</div></div>
+          <div class="stat-card"><div class="stat-number" id="inactiveUsers">0</div><div class="stat-label">Inactive</div></div>
+        </div>
+
+        <table class="user-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Email</th>
+              <th>Role</th>
+              <th>Department</th>
+              <th>Projects</th>
+              <th>Last Login</th>
+              <th>Status</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody id="userTableBody"></tbody>
+        </table>
+      </div>
+    </div>
   </div>
+
   <script type="module" src="firebase.js"></script>
   <script type="module" src="auth.js"></script>
   <script type="module" src="user-management.js"></script>
 </body>
 </html>
+

--- a/user-management.js
+++ b/user-management.js
@@ -3,6 +3,22 @@ import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/fi
 import { collection, getDocs } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
 const tbody = document.getElementById('userTableBody');
+const searchInput = document.getElementById('userSearch');
+
+function formatDate(ts) {
+  if (!ts) return '';
+  const d = ts.toDate ? ts.toDate() : new Date(ts);
+  return d.toLocaleDateString();
+}
+
+function filterRows() {
+  const term = searchInput.value.trim().toLowerCase();
+  tbody.querySelectorAll('tr').forEach(tr => {
+    tr.style.display = tr.textContent.toLowerCase().includes(term) ? '' : 'none';
+  });
+}
+
+searchInput?.addEventListener('input', filterRows);
 
 async function loadUsers() {
   if (!db) return;
@@ -13,9 +29,23 @@ async function loadUsers() {
       const data = doc.data();
       const tr = document.createElement('tr');
       const name = data.displayName || data.name || '';
-      tr.innerHTML = `<td>${name}</td><td>${data.email || ''}</td>`;
+      const role = data.role || '';
+      const dept = data.department || '';
+      const projects = (data.projects || []).length;
+      const last = formatDate(data.lastLogin);
+      const status = data.status || (data.disabled ? 'Suspended' : (data.emailVerified ? 'Active' : 'Pending'));
+      tr.innerHTML = `
+        <td><div class="avatar-name">${name}</div></td>
+        <td>${data.email || ''}</td>
+        <td>${role}</td>
+        <td>${dept}</td>
+        <td>${projects}</td>
+        <td>${last}</td>
+        <td>${status}</td>
+        <td><button class="action-btn secondary small" data-id="${doc.id}">Edit</button></td>`;
       tbody.appendChild(tr);
     });
+    filterRows();
   } catch (e) {
     console.error('Failed to load users', e);
   }


### PR DESCRIPTION
## Summary
- expand the user management HTML page with sidebar navigation and actions
- render more user information in `user-management.js`
- add styles for new UI components

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68571e42dd40832e9c87fe4a3194e98c