### PR TITLE
Add role management system

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -79,6 +79,17 @@ Used for admin notifications.
 - **message**: string *(optional)*
 - other arbitrary fields
 
+## roles (collection)
+- Document id: role identifier (e.g. `admin`)
+- **description**: string *(optional)*
+- **permissions**: array of strings *(optional)*
+
+## userRoles (collection)
+Mapping between users and roles.
+- **userId**: string
+- **roleId**: string (matches role document id)
+- **assignedAt**: timestamp
+
 ## tasks (collection)
 Top-level storage for tasks. Each document mirrors the fields listed in the
 [Tasks subcollection](#tasks-subcollection) and may be referenced from other

--- a/auth.js
+++ b/auth.js
@@ -1,6 +1,6 @@
 import { auth, db } from './firebase.js';
 import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
-import { doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+import { doc, getDoc, collection, getDocs, query, where } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
 onAuthStateChanged(auth, async (user) => {
   window.currentUser = user;
@@ -14,6 +14,19 @@ onAuthStateChanged(auth, async (user) => {
       }
     } catch (e) {
       console.error('Failed to fetch user info', e);
+    }
+    let roles = [];
+    try {
+      const roleSnap = await getDocs(query(collection(db, 'userRoles'), where('userId', '==', user.uid)));
+      roles = roleSnap.docs.map(d => d.data().roleId);
+    } catch (e) {
+      console.error('Failed to fetch user roles', e);
+    }
+    window.currentUserRoles = roles;
+    const required = window.REQUIRED_ROLES;
+    if (required && required.length && !required.some(r => roles.includes(r))) {
+      window.location.href = 'index.html';
+      return;
     }
     const nameEl = document.getElementById('userName');
     if (nameEl && name) nameEl.textContent = name;

--- a/initFirestoreCollections.js
+++ b/initFirestoreCollections.js
@@ -27,6 +27,8 @@ const collections = [
   'apiKeys',
   'rateLimits',
   'userRequests',
+  'roles',
+  'userRoles',
   // Task management
   'tasks',
   'taskComments',

--- a/roles-admin.html
+++ b/roles-admin.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Role Administration - Mumatec Tasking</title>
+  <link id="styleLink" rel="stylesheet" href="styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="style.js"></script>
+  <script>applySavedTheme(); window.REQUIRED_ROLES = ['superAdmin'];</script>
+</head>
+<body>
+  <header class="top-bar">
+    <div class="top-bar-left">
+      <a href="index.html" class="action-btn secondary" aria-label="Back to dashboard"><span class="material-icons">arrow_back</span></a>
+      <h1 class="page-title">Role Administration</h1>
+    </div>
+    <div class="top-bar-right">
+      <div class="user-info" id="userInfo">
+        <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
+        <div class="profile-dropdown" id="profileDropdown">
+          <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+          <button class="dropdown-btn" onclick="logout()">Logout</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <div class="app-container">
+    <div class="main-content">
+      <div class="content-area" style="padding:20px;">
+        <button id="addRole" class="action-btn primary" style="margin-bottom:1rem;"><span class="material-icons">add</span> Add Role</button>
+        <table class="user-table">
+          <thead><tr><th>Role</th><th>Description</th><th>Actions</th></tr></thead>
+          <tbody id="rolesBody"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="auth.js"></script>
+  <script type="module" src="roles-admin.js"></script>
+</body>
+</html>

--- a/roles-admin.js
+++ b/roles-admin.js
@@ -1,0 +1,44 @@
+import { auth, db } from './firebase.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
+import { collection, getDocs, setDoc, doc, getDoc, updateDoc, addDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+
+const tbody = document.getElementById('rolesBody');
+const addBtn = document.getElementById('addRole');
+
+async function loadRoles() {
+  const snap = await getDocs(collection(db, 'roles'));
+  tbody.innerHTML = '';
+  snap.forEach(d => {
+    const data = d.data();
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${d.id}</td><td>${data.description || ''}</td><td><button class="action-btn secondary small" data-id="${d.id}">Edit</button></td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+tbody.addEventListener('click', async e => {
+  const id = e.target.closest('button[data-id]')?.dataset.id;
+  if (!id) return;
+  const snap = await getDoc(doc(db, 'roles', id));
+  const current = snap.exists() ? snap.data().description || '' : '';
+  const desc = prompt('Role description:', current);
+  if (desc === null) return;
+  await updateDoc(doc(db, 'roles', id), { description: desc });
+  loadRoles();
+});
+
+addBtn.addEventListener('click', async () => {
+  const name = prompt('Role name:');
+  if (!name) return;
+  const desc = prompt('Description:') || '';
+  await setDoc(doc(db, 'roles', name.trim()), { description: desc });
+  loadRoles();
+});
+
+onAuthStateChanged(auth, user => {
+  if (!user) {
+    window.location.href = 'login.html';
+  } else {
+    loadRoles();
+  }
+});

--- a/signup.js
+++ b/signup.js
@@ -1,6 +1,6 @@
 import { auth, db } from './firebase.js';
 import { createUserWithEmailAndPassword, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
-import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+import { doc, setDoc, collection, addDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
 document.getElementById('signupForm').addEventListener('submit', async (e) => {
   e.preventDefault();
@@ -33,6 +33,11 @@ document.getElementById('signupForm').addEventListener('submit', async (e) => {
       role: 'client',
       onboarded: false,
       notifications: { email: emailNotif, push: pushNotif }
+    });
+    await addDoc(collection(db, 'userRoles'), {
+      userId: cred.user.uid,
+      roleId: 'client',
+      assignedAt: new Date()
     });
     window.location.href = 'index.html';
   } catch (err) {

--- a/user-management.html
+++ b/user-management.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme();</script>
+  <script>applySavedTheme(); window.REQUIRED_ROLES = ['admin', 'superAdmin'];</script>
 </head>
 <body>
   <header class="top-bar">

--- a/user-management.js
+++ b/user-management.js
@@ -1,9 +1,10 @@
 import { auth, db } from './firebase.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
-import { collection, getDocs } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+import { collection, getDocs, query, where, addDoc, deleteDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
 const tbody = document.getElementById('userTableBody');
 const searchInput = document.getElementById('userSearch');
+let userRolesMap = {};
 
 function formatDate(ts) {
   if (!ts) return '';
@@ -23,13 +24,20 @@ searchInput?.addEventListener('input', filterRows);
 async function loadUsers() {
   if (!db) return;
   try {
+    const roleSnap = await getDocs(collection(db, 'userRoles'));
+    userRolesMap = {};
+    roleSnap.forEach(d => {
+      const data = d.data();
+      if (!userRolesMap[data.userId]) userRolesMap[data.userId] = [];
+      userRolesMap[data.userId].push(data.roleId);
+    });
     const snap = await getDocs(collection(db, 'users'));
     tbody.innerHTML = '';
     snap.forEach(doc => {
       const data = doc.data();
       const tr = document.createElement('tr');
       const name = data.displayName || data.name || '';
-      const role = data.role || '';
+      const role = (userRolesMap[doc.id] || []).join(', ');
       const dept = data.department || '';
       const projects = (data.projects || []).length;
       const last = formatDate(data.lastLogin);
@@ -50,6 +58,26 @@ async function loadUsers() {
     console.error('Failed to load users', e);
   }
 }
+
+tbody.addEventListener('click', async e => {
+  const btn = e.target.closest('button[data-id]');
+  if (!btn) return;
+  const userId = btn.dataset.id;
+  const current = (userRolesMap[userId] || []).join(', ');
+  const input = prompt('Assign roles (comma separated):', current);
+  if (input === null) return;
+  const roles = input.split(',').map(r => r.trim()).filter(Boolean);
+  try {
+    const snap = await getDocs(query(collection(db, 'userRoles'), where('userId', '==', userId)));
+    const ops = [];
+    snap.forEach(d => ops.push(deleteDoc(d.ref)));
+    roles.forEach(r => ops.push(addDoc(collection(db, 'userRoles'), { userId, roleId: r, assignedAt: new Date() })));
+    await Promise.all(ops);
+    loadUsers();
+  } catch (err) {
+    console.error('Failed to update roles', err);
+  }
+});
 
 onAuthStateChanged(auth, user => {
   if (!user) {


### PR DESCRIPTION
## Summary
- provision Firestore `roles` and `userRoles` collections
- store default client role on signup
- enforce required roles in `auth.js`
- show and edit roles in user management
- add a simple role administration page
- document new collections

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685723cfa2f8832e98ed55412fa450cb