### PR TITLE
Add profile management and 2FA

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -12,12 +12,14 @@ This document lists the Firestore collections used by the application and the ma
 - **department**: string *(optional)*
 - **phone**: string *(optional)*
 - **timezone**: string *(optional)*
+- **language**: string *(optional)*
 - **skills**: array of strings *(optional)*
 - **status**: string *(optional)*
 - **notifications**: { email: boolean, push: boolean } *(optional)*
 - **onboarded**: boolean *(optional)*
 - **disabled**: boolean *(optional)*
 - **guestExpiresAt**: timestamp *(optional)*
+- **totpSecret**: string *(optional)*
 - **lastLogin**: timestamp *(optional)*
 - **teams**, **clients**, **projects**: array of ids *(optional)*
 - **managerUid**: string *(optional)*
@@ -25,6 +27,7 @@ This document lists the Firestore collections used by the application and the ma
 ### Subcollections
 - **tasks**: see [Task fields](#tasks-subcollection)
 - **sessions**: { userAgent, startAt, endAt, active }
+- **loginHistory**: { timestamp, userAgent }
 
 ## settings (collection)
 - **taskTypes** document: { types: array of strings }

--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ domain to Firebase Authentication's allowed list. In the Firebase console open
 
 ### Simplified Version
 
-Previous releases included extensive administrative tools, custom roles and a
-profile management system. These features have been removed to keep the project
-lightweight. The current app focuses on basic authentication and task
-management only.
+Previous releases included extensive administrative tools and custom roles.
+The simplified build now reintroduces a lightweight profile page for updating
+personal details, preferred language, timezone and security options such as
+password reset and two-factor authentication. Other advanced features remain
+omitted so the app stays focused on basic authentication and task management.
 
 ## Workflow Documentation
 For an overview of task statuses, priorities, and categories, see [WORKFLOW.md](./WORKFLOW.md).

--- a/index.html
+++ b/index.html
@@ -47,6 +47,9 @@
                     <button class="dropdown-btn" onclick="document.getElementById('csvImport').click()">
                         <span class="material-icons">file_upload</span> Import
                     </button>
+                    <a href="profile.html" class="dropdown-btn">
+                        <span class="material-icons">person</span> Profile
+                    </a>
                     <a href="user-management.html" class="dropdown-btn">
                         <span class="material-icons">manage_accounts</span> User Management
                     </a>

--- a/invite.html
+++ b/invite.html
@@ -22,6 +22,7 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+          <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>
       </div>

--- a/login.html
+++ b/login.html
@@ -27,6 +27,16 @@
       <button type="submit" class="action-btn primary">Login</button>
       <div id="error" class="error"></div>
     </form>
+    <div id="totpContainer" style="display:none;">
+      <form id="totpForm">
+        <div class="form-field">
+          <label for="totpCode">Authentication code</label>
+          <input type="text" id="totpCode" autocomplete="one-time-code" required />
+        </div>
+        <button type="submit" class="action-btn primary">Verify</button>
+        <div id="totpError" class="error"></div>
+      </form>
+    </div>
     <p style="text-align:center;margin-top:0.5rem;">
       <a href="signup.html">Create account</a> |
       <a href="reset.html">Forgot password?</a>

--- a/login.js
+++ b/login.js
@@ -1,9 +1,31 @@
-import { auth } from './firebase.js';
-
+import { auth, db } from './firebase.js';
 import { signInWithEmailAndPassword, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
+import { doc, getDoc, collection, addDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+import { TOTP } from 'https://cdn.jsdelivr.net/npm/otpauth@9.0.0/dist/otpauth.esm.js';
 
 
-document.getElementById('loginForm').addEventListener('submit', async (e) => {
+const loginForm = document.getElementById('loginForm');
+const totpContainer = document.getElementById('totpContainer');
+const totpForm = document.getElementById('totpForm');
+const totpInput = document.getElementById('totpCode');
+const totpError = document.getElementById('totpError');
+
+let pendingUser = null;
+let pendingSecret = null;
+let awaitingTotp = false;
+
+async function recordLogin(user) {
+  try {
+    await addDoc(collection(db, 'users', user.uid, 'loginHistory'), {
+      timestamp: new Date(),
+      userAgent: navigator.userAgent
+    });
+  } catch (err) {
+    console.error('Failed to record login', err);
+  }
+}
+
+loginForm.addEventListener('submit', async (e) => {
   e.preventDefault();
   const email = document.getElementById('email').value.trim();
   const password = document.getElementById('password').value;
@@ -18,17 +40,39 @@ document.getElementById('loginForm').addEventListener('submit', async (e) => {
     'auth/network-request-failed': 'Network error. Check your connection.'
   };
   try {
-    await signInWithEmailAndPassword(auth, email, password);
-
-    window.location.href = 'index.html';
-
+    const cred = await signInWithEmailAndPassword(auth, email, password);
+    const snap = await getDoc(doc(db, 'users', cred.user.uid));
+    const data = snap.exists() ? snap.data() : {};
+    if (data.totpSecret) {
+      awaitingTotp = true;
+      pendingUser = cred.user;
+      pendingSecret = data.totpSecret;
+      loginForm.style.display = 'none';
+      totpContainer.style.display = 'block';
+    } else {
+      await recordLogin(cred.user);
+      window.location.href = 'index.html';
+    }
   } catch (err) {
     errorEl.textContent = messages[err.code] || err.message;
   }
 });
 
+totpForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  const totp = new TOTP({ secret: pendingSecret });
+  const valid = totp.validate({ token: totpInput.value.trim() }) !== null;
+  if (!valid) {
+    totpError.textContent = 'Invalid code.';
+    return;
+  }
+  awaitingTotp = false;
+  await recordLogin(pendingUser);
+  window.location.href = 'index.html';
+});
+
 onAuthStateChanged(auth, (user) => {
-  if (user) {
+  if (user && !awaitingTotp) {
     window.location.href = 'index.html';
   }
 });

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Profile - Mumatec Tasking</title>
+  <link id="styleLink" rel="stylesheet" href="styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="style.js"></script>
+  <script>applySavedTheme();</script>
+</head>
+<body>
+  <header class="top-bar">
+    <div class="top-bar-left">
+      <a href="index.html" class="action-btn secondary" aria-label="Back to dashboard"><span class="material-icons">arrow_back</span></a>
+      <h1 class="page-title">Profile</h1>
+    </div>
+    <div class="top-bar-right">
+      <div class="user-info" id="userInfo">
+        <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
+        <div class="profile-dropdown" id="profileDropdown">
+          <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+          <button class="dropdown-btn" onclick="logout()">Logout</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <div class="app-container">
+    <div class="main-content">
+      <div class="content-area" style="padding:20px;">
+        <div class="profile-container">
+          <h2>Personal Info</h2>
+          <form id="profileForm" class="profile-form">
+            <div class="form-row">
+              <div class="form-field">
+                <label for="name">Name</label>
+                <input type="text" id="name" />
+              </div>
+              <div class="form-field">
+                <label for="phone">Phone</label>
+                <input type="tel" id="phone" />
+              </div>
+            </div>
+            <div class="form-row">
+              <div class="form-field">
+                <label for="language">Language</label>
+                <input type="text" id="language" />
+              </div>
+              <div class="form-field">
+                <label for="timezone">Timezone</label>
+                <input type="text" id="timezone" />
+              </div>
+            </div>
+            <button type="submit" class="action-btn primary">Save Changes</button>
+            <div id="profileMsg" class="error"></div>
+          </form>
+
+          <h2 style="margin-top:2rem;">Reset Password</h2>
+          <form id="pwResetForm">
+            <button type="submit" class="action-btn secondary">Send reset email</button>
+            <div id="pwMsg" class="error"></div>
+          </form>
+
+          <h2 style="margin-top:2rem;">Two-Factor Authentication</h2>
+          <div id="totpSection">
+            <p id="totpStatus"></p>
+            <button id="enableTotp" class="action-btn secondary">Enable 2FA</button>
+            <button id="disableTotp" class="action-btn secondary" style="display:none;">Disable 2FA</button>
+            <div id="totpSetup" style="display:none;margin-top:1rem;">
+              <p>Secret: <span id="totpSecret"></span></p>
+              <form id="totpForm">
+                <div class="form-field">
+                  <label for="totpCode">Enter code</label>
+                  <input type="text" id="totpCode" autocomplete="one-time-code" />
+                </div>
+                <button type="submit" class="action-btn primary">Verify</button>
+                <div id="totpError" class="error"></div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="auth.js"></script>
+  <script type="module" src="profile.js"></script>
+</body>
+</html>

--- a/profile.js
+++ b/profile.js
@@ -1,0 +1,128 @@
+import { auth, db } from './firebase.js';
+import { onAuthStateChanged, sendPasswordResetEmail } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
+import { doc, getDoc, updateDoc, deleteField } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+import { TOTP, Secret } from 'https://cdn.jsdelivr.net/npm/otpauth@9.0.0/dist/otpauth.esm.js';
+
+const nameInput = document.getElementById('name');
+const phoneInput = document.getElementById('phone');
+const tzInput = document.getElementById('timezone');
+const langInput = document.getElementById('language');
+const profileForm = document.getElementById('profileForm');
+const profileMsg = document.getElementById('profileMsg');
+
+const pwResetForm = document.getElementById('pwResetForm');
+const pwMsg = document.getElementById('pwMsg');
+
+const enableBtn = document.getElementById('enableTotp');
+const disableBtn = document.getElementById('disableTotp');
+const totpStatus = document.getElementById('totpStatus');
+const totpSetup = document.getElementById('totpSetup');
+const totpForm = document.getElementById('totpForm');
+const totpSecretEl = document.getElementById('totpSecret');
+const totpCodeInput = document.getElementById('totpCode');
+const totpError = document.getElementById('totpError');
+
+let currentUser = null;
+let tempSecret = null;
+
+function showEnabled() {
+  totpStatus.textContent = 'Two-factor authentication is enabled.';
+  enableBtn.style.display = 'none';
+  disableBtn.style.display = 'block';
+  totpSetup.style.display = 'none';
+}
+
+function showDisabled() {
+  totpStatus.textContent = 'Two-factor authentication is not enabled.';
+  enableBtn.style.display = 'block';
+  disableBtn.style.display = 'none';
+  totpSetup.style.display = 'none';
+  totpSecretEl.textContent = '';
+  totpCodeInput.value = '';
+  totpError.textContent = '';
+}
+
+enableBtn?.addEventListener('click', () => {
+  tempSecret = Secret.generate();
+  totpSecretEl.textContent = tempSecret.base32;
+  totpSetup.style.display = 'block';
+});
+
+totpForm?.addEventListener('submit', async e => {
+  e.preventDefault();
+  const totp = new TOTP({ secret: tempSecret });
+  const valid = totp.validate({ token: totpCodeInput.value.trim() }) !== null;
+  if (!valid) {
+    totpError.textContent = 'Invalid code.';
+    return;
+  }
+  try {
+    await updateDoc(doc(db, 'users', currentUser.uid), { totpSecret: tempSecret.base32 });
+    showEnabled();
+  } catch (err) {
+    totpError.textContent = err.message;
+  }
+});
+
+disableBtn?.addEventListener('click', async () => {
+  try {
+    await updateDoc(doc(db, 'users', currentUser.uid), { totpSecret: deleteField() });
+    showDisabled();
+  } catch (err) {
+    totpStatus.textContent = err.message;
+  }
+});
+
+profileForm?.addEventListener('submit', async e => {
+  e.preventDefault();
+  profileMsg.textContent = '';
+  try {
+    await updateDoc(doc(db, 'users', currentUser.uid), {
+      name: nameInput.value.trim(),
+      phone: phoneInput.value.trim(),
+      timezone: tzInput.value.trim(),
+      language: langInput.value.trim()
+    });
+    profileMsg.textContent = 'Profile updated.';
+  } catch (err) {
+    profileMsg.textContent = err.message;
+  }
+});
+
+pwResetForm?.addEventListener('submit', async e => {
+  e.preventDefault();
+  pwMsg.textContent = '';
+  try {
+    await sendPasswordResetEmail(auth, currentUser.email);
+    pwMsg.textContent = 'Reset email sent.';
+  } catch (err) {
+    pwMsg.textContent = err.message;
+  }
+});
+
+onAuthStateChanged(auth, async user => {
+  if (!user) {
+    window.location.href = 'login.html';
+    return;
+  }
+  currentUser = user;
+  try {
+    const snap = await getDoc(doc(db, 'users', user.uid));
+    if (snap.exists()) {
+      const data = snap.data();
+      nameInput.value = data.name || data.displayName || '';
+      phoneInput.value = data.phone || '';
+      tzInput.value = data.timezone || '';
+      langInput.value = data.language || '';
+      if (data.totpSecret) {
+        showEnabled();
+      } else {
+        showDisabled();
+      }
+    } else {
+      showDisabled();
+    }
+  } catch (err) {
+    console.error('Failed to load profile', err);
+  }
+});

--- a/roles-admin.html
+++ b/roles-admin.html
@@ -22,6 +22,7 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+          <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>
       </div>

--- a/user-management.html
+++ b/user-management.html
@@ -22,6 +22,7 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+          <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add profile page for updating personal info and timezone/language
- integrate password reset and 2FA setup
- record login activity in `loginHistory` subcollection
- add profile link in dropdown menus
- document new schema fields

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68572850ea50832e96d5d3276f34cc6f