### PR TITLE
Implement bulk user management

### DIFF
--- a/user-management.html
+++ b/user-management.html
@@ -84,6 +84,7 @@
         <table class="user-table">
           <thead>
             <tr>
+              <th><input type="checkbox" id="selectAll"></th>
               <th>Name</th>
               <th>Email</th>
               <th>Role</th>
@@ -96,6 +97,30 @@
           </thead>
           <tbody id="userTableBody"></tbody>
         </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal-overlay" id="bulkModal" aria-hidden="true">
+    <div class="task-modal">
+      <div class="modal-header">
+        <h3>Bulk Edit Users</h3>
+        <button class="close-btn" id="bulkClose"><span class="material-icons">close</span></button>
+      </div>
+      <div class="form-field">
+        <label>Assign Roles</label>
+        <select id="bulkRoles" multiple></select>
+      </div>
+      <div class="form-field">
+        <label>Assign Project</label>
+        <select id="bulkProject"></select>
+      </div>
+      <div class="form-field">
+        <label><input type="checkbox" id="bulkDeactivate"> Deactivate Users</label>
+      </div>
+      <div class="quick-actions">
+        <button class="quick-btn secondary" id="bulkCancel">Cancel</button>
+        <button class="quick-btn primary" id="bulkApply">Apply</button>
       </div>
     </div>
   </div>

--- a/user-management.js
+++ b/user-management.js
@@ -1,15 +1,43 @@
 import { auth, db } from './firebase.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
-import { collection, getDocs, query, where, addDoc, deleteDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+import { collection, getDocs, query, where, addDoc, deleteDoc, doc, writeBatch, updateDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
 const tbody = document.getElementById('userTableBody');
 const searchInput = document.getElementById('userSearch');
+const bulkBtn = document.getElementById('bulkEditBtn');
+const bulkModal = document.getElementById('bulkModal');
+const bulkRolesSel = document.getElementById('bulkRoles');
+const bulkProjectSel = document.getElementById('bulkProject');
+const bulkDeactivateChk = document.getElementById('bulkDeactivate');
+const bulkApplyBtn = document.getElementById('bulkApply');
+const bulkCancelBtn = document.getElementById('bulkCancel');
+const bulkCloseBtn = document.getElementById('bulkClose');
+const selectAll = document.getElementById('selectAll');
 let userRolesMap = {};
 let availableRoles = [];
+let availableProjects = [];
+const selectedUsers = new Set();
 
 async function fetchRoles() {
   const snap = await getDocs(collection(db, 'roles'));
   availableRoles = snap.docs.map(d => d.id);
+  if (bulkRolesSel) {
+    bulkRolesSel.innerHTML = availableRoles.map(r => `<option value="${r}">${r}</option>`).join('');
+  }
+}
+
+async function fetchProjects() {
+  try {
+    const snap = await getDocs(collection(db, 'projects'));
+    availableProjects = snap.docs.map(d => ({ id: d.id, ...(d.data() || {}) }));
+    if (bulkProjectSel) {
+      const opts = ['<option value="">None</option>'];
+      opts.push(...availableProjects.map(p => `<option value="${p.id}">${p.name || p.id}</option>`));
+      bulkProjectSel.innerHTML = opts.join('');
+    }
+  } catch (e) {
+    console.error('Failed to fetch projects', e);
+  }
 }
 
 function formatDate(ts) {
@@ -27,6 +55,24 @@ function filterRows() {
 
 searchInput?.addEventListener('input', filterRows);
 
+tbody.addEventListener('change', e => {
+  const cb = e.target.closest('.row-select');
+  if (!cb) return;
+  if (cb.checked) {
+    selectedUsers.add(cb.dataset.id);
+  } else {
+    selectedUsers.delete(cb.dataset.id);
+  }
+});
+
+selectAll?.addEventListener('change', () => {
+  const checked = selectAll.checked;
+  tbody.querySelectorAll('.row-select').forEach(cb => {
+    cb.checked = checked;
+    if (checked) selectedUsers.add(cb.dataset.id); else selectedUsers.delete(cb.dataset.id);
+  });
+});
+
 async function loadUsers() {
   if (!db) return;
   try {
@@ -39,6 +85,8 @@ async function loadUsers() {
     });
     const snap = await getDocs(collection(db, 'users'));
     tbody.innerHTML = '';
+    selectedUsers.clear();
+    if (selectAll) selectAll.checked = false;
     snap.forEach(doc => {
       const data = doc.data();
       const tr = document.createElement('tr');
@@ -49,6 +97,7 @@ async function loadUsers() {
       const last = formatDate(data.lastLogin);
       const status = data.status || (data.disabled ? 'Suspended' : (data.emailVerified ? 'Active' : 'Pending'));
       tr.innerHTML = `
+        <td><input type="checkbox" class="row-select" data-id="${doc.id}"></td>
         <td><div class="avatar-name">${name}</div></td>
         <td>${data.email || ''}</td>
         <td>${role}</td>
@@ -85,10 +134,60 @@ tbody.addEventListener('click', async e => {
   }
 });
 
+function openBulkModal() {
+  bulkModal.classList.add('active');
+  bulkModal.setAttribute('aria-hidden', 'false');
+}
+
+function closeBulkModal() {
+  bulkModal.classList.remove('active');
+  bulkModal.setAttribute('aria-hidden', 'true');
+}
+
+bulkBtn?.addEventListener('click', () => {
+  if (selectedUsers.size === 0) {
+    alert('Select users first');
+    return;
+  }
+  openBulkModal();
+});
+
+bulkCloseBtn?.addEventListener('click', closeBulkModal);
+bulkCancelBtn?.addEventListener('click', closeBulkModal);
+bulkModal?.addEventListener('click', e => { if (e.target === bulkModal) closeBulkModal(); });
+
+bulkApplyBtn?.addEventListener('click', async () => {
+  const roles = Array.from(bulkRolesSel.selectedOptions).map(o => o.value).filter(Boolean);
+  const projectId = bulkProjectSel.value;
+  const deactivate = bulkDeactivateChk.checked;
+  if (!roles.length && !projectId && !deactivate) { closeBulkModal(); return; }
+  try {
+    const batch = writeBatch(db);
+    for (const uid of selectedUsers) {
+      if (roles.length) {
+        const snap = await getDocs(query(collection(db, 'userRoles'), where('userId', '==', uid)));
+        snap.forEach(d => batch.delete(d.ref));
+        roles.forEach(r => batch.set(doc(collection(db, 'userRoles')), { userId: uid, roleId: r, assignedAt: new Date() }));
+      }
+      if (projectId) {
+        batch.set(doc(db, 'users', uid), { projects: [projectId] }, { merge: true });
+      }
+      if (deactivate) {
+        batch.update(doc(db, 'users', uid), { disabled: true });
+      }
+    }
+    await batch.commit();
+    closeBulkModal();
+    loadUsers();
+  } catch (err) {
+    console.error('Failed to apply bulk changes', err);
+  }
+});
+
 onAuthStateChanged(auth, user => {
   if (!user) {
     window.location.href = 'login.html';
   } else {
-    fetchRoles().then(loadUsers);
+    Promise.all([fetchRoles(), fetchProjects()]).then(loadUsers);
   }
 });


### PR DESCRIPTION
## Summary
- add selection checkboxes and bulk edit modal
- implement bulk role/project update and deactivation in user-management.js
- fetch projects for modal select

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6857417aa340832eb59fa4ae24e0c3a3