### PR TITLE
Add audit logging and viewer

### DIFF
--- a/audit.html
+++ b/audit.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Audit Logs - Mumatec Tasking</title>
+  <link id="styleLink" rel="stylesheet" href="styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="style.js"></script>
+  <script>applySavedTheme(); window.REQUIRED_ROLES = ['admin','superAdmin'];</script>
+</head>
+<body>
+  <header class="top-bar">
+    <div class="top-bar-left">
+      <a href="index.html" class="action-btn secondary" aria-label="Back to dashboard"><span class="material-icons">arrow_back</span></a>
+      <h1 class="page-title">Audit Logs</h1>
+    </div>
+    <div class="top-bar-right">
+      <div class="user-info" id="userInfo">
+        <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
+        <div class="profile-dropdown" id="profileDropdown">
+          <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+          <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
+          <button class="dropdown-btn" onclick="logout()">Logout</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <div class="app-container">
+    <div class="main-content">
+      <div class="content-area" style="padding:20px;">
+        <div class="user-filters" style="margin-bottom:1rem;">
+          <input type="text" id="userFilter" class="search-input" placeholder="Admin UID">
+          <input type="date" id="startDate">
+          <input type="date" id="endDate">
+          <button class="action-btn secondary small" id="loadLogs">Filter</button>
+        </div>
+        <table class="user-table">
+          <thead><tr><th>Timestamp</th><th>Admin</th><th>Action</th><th>Target</th><th>Extra</th></tr></thead>
+          <tbody id="auditBody"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="auth.js"></script>
+  <script type="module" src="audit.js"></script>
+</body>
+</html>

--- a/audit.js
+++ b/audit.js
@@ -1,0 +1,48 @@
+import { auth, db } from './firebase.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
+import { collection, getDocs, query, where, orderBy } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+
+const tbody = document.getElementById('auditBody');
+const userInput = document.getElementById('userFilter');
+const startInput = document.getElementById('startDate');
+const endInput = document.getElementById('endDate');
+const loadBtn = document.getElementById('loadLogs');
+
+function endOfDay(date) {
+  const d = new Date(date);
+  d.setHours(23, 59, 59, 999);
+  return d;
+}
+
+async function loadLogs() {
+  if (!db) return;
+  let q = collection(db, 'auditLogs');
+  const filters = [];
+  if (userInput.value.trim()) filters.push(where('adminUid', '==', userInput.value.trim()));
+  if (startInput.value) filters.push(where('timestamp', '>=', new Date(startInput.value)));
+  if (endInput.value) filters.push(where('timestamp', '<=', endOfDay(endInput.value)));
+  if (filters.length) {
+    q = query(q, ...filters, orderBy('timestamp', 'desc'));
+  } else {
+    q = query(q, orderBy('timestamp', 'desc'));
+  }
+  const snap = await getDocs(q);
+  tbody.innerHTML = '';
+  snap.forEach(d => {
+    const data = d.data();
+    const ts = data.timestamp?.toDate ? data.timestamp.toDate().toLocaleString() : '';
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${ts}</td><td>${data.adminUid}</td><td>${data.action}</td><td>${data.targetUid || ''}</td><td>${data.extra ? JSON.stringify(data.extra) : ''}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+loadBtn?.addEventListener('click', loadLogs);
+
+onAuthStateChanged(auth, user => {
+  if (!user) {
+    window.location.href = 'login.html';
+  } else {
+    loadLogs();
+  }
+});

--- a/auth.js
+++ b/auth.js
@@ -1,6 +1,6 @@
 import { auth, db } from './firebase.js';
 import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
-import { doc, getDoc, collection, getDocs, query, where } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
+import { doc, getDoc, collection, getDocs, query, where, addDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
 onAuthStateChanged(auth, async (user) => {
   window.currentUser = user;
@@ -53,3 +53,18 @@ onAuthStateChanged(auth, async (user) => {
 });
 
 window.logout = () => signOut(auth);
+
+export async function logAuditAction(adminUid, action, targetUid = null, extra = null) {
+  if (!adminUid) return;
+  try {
+    await addDoc(collection(db, 'auditLogs'), {
+      adminUid,
+      action,
+      targetUid: targetUid || null,
+      extra: extra || null,
+      timestamp: new Date()
+    });
+  } catch (err) {
+    console.error('Failed to log audit action', err);
+  }
+}

--- a/invite.js
+++ b/invite.js
@@ -1,4 +1,5 @@
 import { auth, db } from './firebase.js';
+import { logAuditAction } from './auth.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
 import { collection, getDocs, addDoc, deleteDoc, doc, updateDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
@@ -39,6 +40,7 @@ tbody.addEventListener('click', async e => {
   const id = e.target.closest('button[data-id]')?.dataset.id;
   if (!id) return;
   await deleteDoc(doc(db, 'invites', id));
+  logAuditAction(auth.currentUser?.uid, 'inviteDeleted', null, { inviteId: id });
   loadInvites();
 });
 
@@ -55,6 +57,7 @@ addBtn.addEventListener('click', async () => {
     status: 'sent',
     createdAt: new Date()
   });
+  logAuditAction(auth.currentUser?.uid, 'inviteSent', null, { email: email.trim(), roleId: roleId.trim(), projectId: projectId ? projectId.trim() : null });
   loadInvites();
 });
 

--- a/roles-admin.js
+++ b/roles-admin.js
@@ -1,4 +1,5 @@
 import { auth, db } from './firebase.js';
+import { logAuditAction } from './auth.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
 import { collection, getDocs, setDoc, doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
@@ -28,6 +29,7 @@ tbody.addEventListener('click', async e => {
   if (permsInput === null) return;
   const permissions = permsInput.split(',').map(p => p.trim()).filter(Boolean);
   await setDoc(doc(db, 'roles', id), { description: desc, permissions }, { merge: true });
+  logAuditAction(auth.currentUser?.uid, 'updateRole', id, { description: desc, permissions });
   loadRoles();
 });
 
@@ -38,6 +40,7 @@ addBtn.addEventListener('click', async () => {
   const permsInput = prompt('Permissions (comma separated):') || '';
   const permissions = permsInput.split(',').map(p => p.trim()).filter(Boolean);
   await setDoc(doc(db, 'roles', name.trim()), { description: desc, permissions });
+  logAuditAction(auth.currentUser?.uid, 'createRole', name.trim(), { description: desc, permissions });
   loadRoles();
 });
 

--- a/user-management.html
+++ b/user-management.html
@@ -52,10 +52,10 @@
           <span class="material-icons nav-icon">mail</span>
           <span class="nav-label">Pending Invitations</span>
         </a>
-        <div class="nav-item" aria-label="Audit Logs">
+        <a href="audit.html" class="nav-item" aria-label="Audit Logs">
           <span class="material-icons nav-icon">list_alt</span>
           <span class="nav-label">Audit Logs</span>
-        </div>
+        </a>
         <div class="nav-item" aria-label="Bulk Actions">
           <span class="material-icons nav-icon">playlist_add_check</span>
           <span class="nav-label">Bulk Actions</span>

--- a/user-management.js
+++ b/user-management.js
@@ -1,4 +1,5 @@
 import { auth, db } from './firebase.js';
+import { logAuditAction } from './auth.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
 import { collection, getDocs, query, where, addDoc, deleteDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
@@ -79,6 +80,7 @@ tbody.addEventListener('click', async e => {
     snap.forEach(d => ops.push(deleteDoc(d.ref)));
     roles.forEach(r => ops.push(addDoc(collection(db, 'userRoles'), { userId, roleId: r, assignedAt: new Date() })));
     await Promise.all(ops);
+    logAuditAction(auth.currentUser?.uid, 'setUserRoles', userId, { roles });
     loadUsers();
   } catch (err) {
     console.error('Failed to update roles', err);


### PR DESCRIPTION
## Summary
- add `logAuditAction` helper in `auth.js`
- log audit records when invites are created/deleted, roles are changed and users' roles modified
- link to new **Audit Logs** page from user management
- add new `audit.html` and `audit.js` to display logs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685741933f14832eb14282b110686b62