### PR TITLE
Add admin feature modals

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1396,6 +1396,12 @@ body {
     color: var(--text-primary);
 }
 
+.modal-iframe {
+    width: 100%;
+    height: 70vh;
+    border: none;
+}
+
 .modal-header {
     padding: 24px 24px 0;
     display: flex;

--- a/user-management.html
+++ b/user-management.html
@@ -36,27 +36,27 @@
           <span class="material-icons nav-icon">people</span>
           <span class="nav-label">All Users</span>
         </div>
-        <div class="nav-item" aria-label="User Roles &amp; Permissions">
+        <div class="nav-item" aria-label="User Roles &amp; Permissions" data-target="rolesModal">
           <span class="material-icons nav-icon">security</span>
           <span class="nav-label">User Roles &amp; Permissions</span>
         </div>
-        <a href="departments.html" class="nav-item" aria-label="Departments/Teams">
+        <div class="nav-item" aria-label="Departments/Teams" data-target="departmentsModal">
           <span class="material-icons nav-icon">groups</span>
           <span class="nav-label">Departments/Teams</span>
-        </a>
-        <div class="nav-item" aria-label="Inactive Users">
+        </div>
+        <div class="nav-item" aria-label="Inactive Users" data-target="inactiveModal">
           <span class="material-icons nav-icon">person_off</span>
           <span class="nav-label">Inactive Users</span>
         </div>
-        <a href="invite.html" class="nav-item" aria-label="Pending Invitations">
+        <div class="nav-item" aria-label="Pending Invitations" data-target="invitesModal">
           <span class="material-icons nav-icon">mail</span>
           <span class="nav-label">Pending Invitations</span>
-        </a>
-        <a href="audit.html" class="nav-item" aria-label="Audit Logs">
+        </div>
+        <div class="nav-item" aria-label="Audit Logs" data-target="auditModal">
           <span class="material-icons nav-icon">list_alt</span>
           <span class="nav-label">Audit Logs</span>
-        </a>
-        <div class="nav-item" aria-label="Bulk Actions">
+        </div>
+        <div class="nav-item" aria-label="Bulk Actions" data-target="bulkModal">
           <span class="material-icons nav-icon">playlist_add_check</span>
           <span class="nav-label">Bulk Actions</span>
         </div>
@@ -123,6 +123,61 @@
         <button class="quick-btn secondary" id="bulkCancel">Cancel</button>
         <button class="quick-btn primary" id="bulkApply">Apply</button>
       </div>
+    </div>
+  </div>
+
+  <div class="modal-overlay" id="rolesModal" aria-hidden="true">
+    <div class="task-modal">
+      <div class="modal-header">
+        <h3>User Roles &amp; Permissions</h3>
+        <button class="close-btn" id="rolesClose"><span class="material-icons">close</span></button>
+      </div>
+      <iframe src="roles-admin.html" class="modal-iframe"></iframe>
+    </div>
+  </div>
+
+  <div class="modal-overlay" id="departmentsModal" aria-hidden="true">
+    <div class="task-modal">
+      <div class="modal-header">
+        <h3>Departments &amp; Teams</h3>
+        <button class="close-btn" id="departmentsClose"><span class="material-icons">close</span></button>
+      </div>
+      <iframe src="departments.html" class="modal-iframe"></iframe>
+    </div>
+  </div>
+
+  <div class="modal-overlay" id="invitesModal" aria-hidden="true">
+    <div class="task-modal">
+      <div class="modal-header">
+        <h3>Pending Invitations</h3>
+        <button class="close-btn" id="invitesClose"><span class="material-icons">close</span></button>
+      </div>
+      <iframe src="invite.html" class="modal-iframe"></iframe>
+    </div>
+  </div>
+
+  <div class="modal-overlay" id="auditModal" aria-hidden="true">
+    <div class="task-modal">
+      <div class="modal-header">
+        <h3>Audit Logs</h3>
+        <button class="close-btn" id="auditClose"><span class="material-icons">close</span></button>
+      </div>
+      <iframe src="audit.html" class="modal-iframe"></iframe>
+    </div>
+  </div>
+
+  <div class="modal-overlay" id="inactiveModal" aria-hidden="true">
+    <div class="task-modal">
+      <div class="modal-header">
+        <h3>Inactive Users</h3>
+        <button class="close-btn" id="inactiveClose"><span class="material-icons">close</span></button>
+      </div>
+      <table class="user-table">
+        <thead>
+          <tr><th>Name</th><th>Email</th><th>Last Login</th></tr>
+        </thead>
+        <tbody id="inactiveBody"></tbody>
+      </table>
     </div>
   </div>
 

--- a/user-management.js
+++ b/user-management.js
@@ -15,6 +15,24 @@ const bulkApplyBtn = document.getElementById('bulkApply');
 const bulkCancelBtn = document.getElementById('bulkCancel');
 const bulkCloseBtn = document.getElementById('bulkClose');
 const selectAll = document.getElementById('selectAll');
+const rolesNav = document.querySelector('.nav-item[aria-label="User Roles & Permissions"]');
+const departmentsNav = document.querySelector('.nav-item[aria-label="Departments/Teams"]');
+const invitesNav = document.querySelector('.nav-item[aria-label="Pending Invitations"]');
+const auditNav = document.querySelector('.nav-item[aria-label="Audit Logs"]');
+const inactiveNav = document.querySelector('.nav-item[aria-label="Inactive Users"]');
+const bulkNav = document.querySelector('.nav-item[aria-label="Bulk Actions"]');
+
+const rolesModal = document.getElementById('rolesModal');
+const rolesClose = document.getElementById('rolesClose');
+const departmentsModal = document.getElementById('departmentsModal');
+const departmentsClose = document.getElementById('departmentsClose');
+const invitesModal = document.getElementById('invitesModal');
+const invitesClose = document.getElementById('invitesClose');
+const auditModal = document.getElementById('auditModal');
+const auditClose = document.getElementById('auditClose');
+const inactiveModal = document.getElementById('inactiveModal');
+const inactiveClose = document.getElementById('inactiveClose');
+const inactiveBody = document.getElementById('inactiveBody');
 let userRolesMap = {};
 let availableRoles = [];
 let availableProjects = [];
@@ -130,6 +148,26 @@ async function loadUsers() {
   }
 }
 
+async function loadInactiveUsers() {
+  if (!db) return;
+  try {
+    const snap = await getDocs(collection(db, 'users'));
+    inactiveBody.innerHTML = '';
+    snap.forEach(doc => {
+      const data = doc.data();
+      if (data.disabled || data.status === 'inactive') {
+        const tr = document.createElement('tr');
+        const name = data.displayName || data.name || '';
+        const last = formatDate(data.lastLogin);
+        tr.innerHTML = `<td>${name}</td><td>${data.email || ''}</td><td>${last}</td>`;
+        inactiveBody.appendChild(tr);
+      }
+    });
+  } catch (e) {
+    console.error('Failed to load inactive users', e);
+  }
+}
+
 tbody.addEventListener('click', async e => {
   const btn = e.target.closest('button[data-id]');
   if (!btn) return;
@@ -180,6 +218,16 @@ function closeBulkModal() {
   bulkModal.setAttribute('aria-hidden', 'true');
 }
 
+function openModal(modal) {
+  modal.classList.add('active');
+  modal.setAttribute('aria-hidden', 'false');
+}
+
+function closeModal(modal) {
+  modal.classList.remove('active');
+  modal.setAttribute('aria-hidden', 'true');
+}
+
 bulkBtn?.addEventListener('click', () => {
   if (selectedUsers.size === 0) {
     alert('Select users first');
@@ -219,6 +267,28 @@ bulkApplyBtn?.addEventListener('click', async () => {
     console.error('Failed to apply bulk changes', err);
   }
 });
+
+rolesNav?.addEventListener('click', () => openModal(rolesModal));
+rolesClose?.addEventListener('click', () => closeModal(rolesModal));
+rolesModal?.addEventListener('click', e => { if (e.target === rolesModal) closeModal(rolesModal); });
+
+departmentsNav?.addEventListener('click', () => openModal(departmentsModal));
+departmentsClose?.addEventListener('click', () => closeModal(departmentsModal));
+departmentsModal?.addEventListener('click', e => { if (e.target === departmentsModal) closeModal(departmentsModal); });
+
+invitesNav?.addEventListener('click', () => openModal(invitesModal));
+invitesClose?.addEventListener('click', () => closeModal(invitesModal));
+invitesModal?.addEventListener('click', e => { if (e.target === invitesModal) closeModal(invitesModal); });
+
+auditNav?.addEventListener('click', () => openModal(auditModal));
+auditClose?.addEventListener('click', () => closeModal(auditModal));
+auditModal?.addEventListener('click', e => { if (e.target === auditModal) closeModal(auditModal); });
+
+bulkNav?.addEventListener('click', () => openBulkModal());
+
+inactiveNav?.addEventListener('click', () => { loadInactiveUsers(); openModal(inactiveModal); });
+inactiveClose?.addEventListener('click', () => closeModal(inactiveModal));
+inactiveModal?.addEventListener('click', e => { if (e.target === inactiveModal) closeModal(inactiveModal); });
 
 onAuthStateChanged(auth, user => {
   if (!user) {


### PR DESCRIPTION
## Summary
- enable management modals in **user-management.html**
- load additional modals from existing pages
- support inactive user list
- add generic modal helpers
- style embedded page iframes

## Testing
- `npm run init:collections` *(fails: Cannot find module 'firebase-admin/app')*

------
https://chatgpt.com/codex/tasks/task_e_685745a8e460832e8fcafa8d7abc0af5