### PR TITLE
Fix modal dropdown text visibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1266,6 +1266,11 @@ body {
     display: flex;
 }
 
+/* Ensure dropdown text in modals remains visible */
+.modal-overlay select option {
+    color: #000;
+}
+
 .quick-capture-modal {
     background: var(--background);
     border-radius: var(--border-radius-lg);


### PR DESCRIPTION
## Summary
- ensure modal select options use black text for better contrast

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run dev -- --version` *(fails: serve not found)*

------
https://chatgpt.com/codex/tasks/task_e_685747fece54832eb85ba6fc30a43ab6