### PR TITLE
Add super admin protections

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2220,3 +2220,12 @@ body.dark-mode {
   border-radius: 4px;
 }
 
+.action-btn.danger {
+  background: #e74c3c;
+  color: #fff;
+}
+
+.action-btn.danger:hover {
+  background: #c0392b;
+}
+


### PR DESCRIPTION
## Summary
- protect `superAdmin` role from removal and prevent deletion of master users
- allow super admins to delete other users through a new button
- style new destructive action button

## Testing
- `node -e "console.log('Node works')"`

------
https://chatgpt.com/codex/tasks/task_e_685748bdcf38832e882c614753986f41