### PR TITLE
Add nested role editing modal

### DIFF
--- a/roles-admin.html
+++ b/roles-admin.html
@@ -41,6 +41,37 @@
     </div>
   </div>
 
+  <div class="modal-overlay" id="editRoleModal" aria-hidden="true">
+    <div class="task-modal">
+      <div class="modal-header">
+        <h3 id="editRoleTitle">Add Role</h3>
+        <button class="close-btn" id="editRoleClose"><span class="material-icons">close</span></button>
+      </div>
+      <form id="roleForm">
+        <div class="form-field">
+          <label>Role Name</label>
+          <input type="text" id="roleName" required>
+        </div>
+        <div class="form-field">
+          <label>Description</label>
+          <input type="text" id="roleDesc">
+        </div>
+        <div class="form-field">
+          <label>Permissions (comma separated)</label>
+          <input type="text" id="rolePerms">
+        </div>
+        <div class="form-field">
+          <label>Parent Role</label>
+          <select id="roleParent"></select>
+        </div>
+        <div class="quick-actions">
+          <button type="button" class="quick-btn secondary" id="roleCancel">Cancel</button>
+          <button type="submit" class="quick-btn primary">Save</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
   <script type="module" src="firebase.js"></script>
   <script type="module" src="auth.js"></script>
   <script type="module" src="roles-admin.js"></script>

--- a/roles-admin.js
+++ b/roles-admin.js
@@ -3,6 +3,17 @@ import { logAuditAction } from './auth.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
 import { collection, getDocs, setDoc, doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
+const editRoleModal = document.getElementById('editRoleModal');
+const editRoleClose = document.getElementById('editRoleClose');
+const roleForm = document.getElementById('roleForm');
+const roleNameInput = document.getElementById('roleName');
+const roleDescInput = document.getElementById('roleDesc');
+const rolePermsInput = document.getElementById('rolePerms');
+const roleParentSelect = document.getElementById('roleParent');
+const editRoleTitle = document.getElementById('editRoleTitle');
+const roleCancelBtn = document.getElementById('roleCancel');
+let editingRoleId = null;
+
 const tbody = document.getElementById('rolesBody');
 const addBtn = document.getElementById('addRole');
 
@@ -19,33 +30,74 @@ async function loadRoles() {
   });
 }
 
-tbody.addEventListener('click', async e => {
+function openModal(modal) {
+  modal.classList.add('active');
+  modal.setAttribute('aria-hidden', 'false');
+}
+
+function closeModal(modal) {
+  modal.classList.remove('active');
+  modal.setAttribute('aria-hidden', 'true');
+}
+
+async function populateParentRoles(excludeId) {
+  const snap = await getDocs(collection(db, 'roles'));
+  roleParentSelect.innerHTML = '<option value="">None</option>';
+  snap.forEach(d => {
+    if (d.id !== excludeId) {
+      const opt = document.createElement('option');
+      opt.value = d.id;
+      opt.textContent = d.id;
+      roleParentSelect.appendChild(opt);
+    }
+  });
+}
+
+async function showEditModal(id) {
+  editingRoleId = id || null;
+  roleForm.reset();
+  roleNameInput.disabled = !!id;
+  await populateParentRoles(id);
+  if (id) {
+    const snap = await getDoc(doc(db, 'roles', id));
+    const data = snap.exists() ? snap.data() : {};
+    roleNameInput.value = id;
+    roleDescInput.value = data.description || '';
+    rolePermsInput.value = (data.permissions || []).join(', ');
+    roleParentSelect.value = data.parentRole || '';
+    editRoleTitle.textContent = 'Edit Role';
+  } else {
+    editRoleTitle.textContent = 'Add Role';
+  }
+  openModal(editRoleModal);
+}
+
+tbody.addEventListener('click', e => {
   const id = e.target.closest('button[data-id]')?.dataset.id;
   if (!id) return;
-  const snap = await getDoc(doc(db, 'roles', id));
-  const data = snap.exists() ? snap.data() : {};
-  const desc = prompt('Role description:', data.description || '')
-  if (desc === null) return;
-  const permsInput = prompt('Permissions (comma separated):', (data.permissions || []).join(', '));
-  if (permsInput === null) return;
-  const parentRole = prompt('Parent role (optional):', data.parentRole || '') || '';
-  const permissions = permsInput.split(',').map(p => p.trim()).filter(Boolean);
-  await setDoc(doc(db, 'roles', id), { description: desc, permissions }, { merge: true });
-  logAuditAction(auth.currentUser?.uid, 'updateRole', id, { description: desc, permissions });
-
-  loadRoles();
+  showEditModal(id);
 });
 
-addBtn.addEventListener('click', async () => {
-  const name = prompt('Role name:');
-  if (!name) return;
-  const desc = prompt('Description:') || '';
-  const permsInput = prompt('Permissions (comma separated):') || '';
-  const parentRole = prompt('Parent role (optional):') || '';
-  const permissions = permsInput.split(',').map(p => p.trim()).filter(Boolean);
-  await setDoc(doc(db, 'roles', name.trim()), { description: desc, permissions });
-  logAuditAction(auth.currentUser?.uid, 'createRole', name.trim(), { description: desc, permissions });
+addBtn.addEventListener('click', () => {
+  showEditModal();
+});
 
+editRoleClose.addEventListener('click', () => closeModal(editRoleModal));
+roleCancelBtn.addEventListener('click', () => closeModal(editRoleModal));
+editRoleModal.addEventListener('click', e => { if (e.target === editRoleModal) closeModal(editRoleModal); });
+
+roleForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  const name = roleNameInput.value.trim();
+  if (!name) return;
+  const desc = roleDescInput.value.trim();
+  const permsInput = rolePermsInput.value;
+  const parentRole = roleParentSelect.value;
+  const permissions = permsInput.split(',').map(p => p.trim()).filter(Boolean);
+  await setDoc(doc(db, 'roles', name), { description: desc, permissions, parentRole }, { merge: true });
+  const action = editingRoleId ? 'updateRole' : 'createRole';
+  logAuditAction(auth.currentUser?.uid, action, name, { description: desc, permissions, parentRole });
+  closeModal(editRoleModal);
   loadRoles();
 });
 


### PR DESCRIPTION
## Summary
- enable nested modal editing for roles
- add modal markup to `roles-admin.html`
- implement modal logic in `roles-admin.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68574a4651d8832ebefd69be232fe0ce