### PR TITLE
Fix header display in management modals

### DIFF
--- a/audit.html
+++ b/audit.html
@@ -49,5 +49,12 @@
   <script type="module" src="firebase.js"></script>
   <script type="module" src="auth.js"></script>
   <script type="module" src="audit.js"></script>
+  <script>
+    if (window.self !== window.top) {
+      const header = document.querySelector('.top-bar');
+      if (header) header.remove();
+      document.documentElement.style.setProperty('--top-bar-height', '0px');
+    }
+  </script>
 </body>
 </html>

--- a/departments.html
+++ b/departments.html
@@ -53,5 +53,12 @@
   <script type="module" src="firebase.js"></script>
   <script type="module" src="auth.js"></script>
   <script type="module" src="departments.js"></script>
+  <script>
+    if (window.self !== window.top) {
+      const header = document.querySelector('.top-bar');
+      if (header) header.remove();
+      document.documentElement.style.setProperty('--top-bar-height', '0px');
+    }
+  </script>
 </body>
 </html>

--- a/invite.html
+++ b/invite.html
@@ -44,5 +44,12 @@
   <script type="module" src="firebase.js"></script>
   <script type="module" src="auth.js"></script>
   <script type="module" src="invite.js"></script>
+  <script>
+    if (window.self !== window.top) {
+      const header = document.querySelector('.top-bar');
+      if (header) header.remove();
+      document.documentElement.style.setProperty('--top-bar-height', '0px');
+    }
+  </script>
 </body>
 </html>

--- a/roles-admin.html
+++ b/roles-admin.html
@@ -44,5 +44,12 @@
   <script type="module" src="firebase.js"></script>
   <script type="module" src="auth.js"></script>
   <script type="module" src="roles-admin.js"></script>
+  <script>
+    if (window.self !== window.top) {
+      const header = document.querySelector('.top-bar');
+      if (header) header.remove();
+      document.documentElement.style.setProperty('--top-bar-height', '0px');
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- hide the full page header when roles, departments, invites and audit pages are embedded in modals

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68574b9568cc832e82d1569b3f793afa