### PR TITLE
Add permissions editing modal

### DIFF
--- a/roles-admin.html
+++ b/roles-admin.html
@@ -42,7 +42,7 @@
   </div>
 
   <div class="modal-overlay" id="editRoleModal" aria-hidden="true">
-    <div class="task-modal">
+    <div class="task-modal large-modal">
       <div class="modal-header">
         <h3 id="editRoleTitle">Add Role</h3>
         <button class="close-btn" id="editRoleClose"><span class="material-icons">close</span></button>
@@ -57,8 +57,11 @@
           <input type="text" id="roleDesc">
         </div>
         <div class="form-field">
-          <label>Permissions (comma separated)</label>
-          <input type="text" id="rolePerms">
+          <label>Permissions</label>
+          <div style="display:flex;gap:8px;align-items:center;">
+            <input type="text" id="rolePerms" readonly>
+            <button type="button" class="action-btn secondary small" id="editPermsBtn">Edit</button>
+          </div>
         </div>
         <div class="form-field">
           <label>Parent Role</label>
@@ -69,6 +72,23 @@
           <button type="submit" class="quick-btn primary">Save</button>
         </div>
       </form>
+    </div>
+  </div>
+
+  <div class="modal-overlay" id="permissionsModal" aria-hidden="true">
+    <div class="task-modal large-modal">
+      <div class="modal-header">
+        <h3>Edit Permissions</h3>
+        <button class="close-btn" id="permClose"><span class="material-icons">close</span></button>
+      </div>
+      <div class="form-field">
+        <label><input type="checkbox" id="permSelectAll"> Select All</label>
+      </div>
+      <div id="permissionsContainer" class="permissions-container"></div>
+      <div class="quick-actions">
+        <button type="button" class="quick-btn secondary" id="permCancel">Cancel</button>
+        <button type="button" class="quick-btn primary" id="permSave">Save</button>
+      </div>
     </div>
   </div>
 

--- a/roles-admin.js
+++ b/roles-admin.js
@@ -3,6 +3,75 @@ import { logAuditAction } from './auth.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js';
 import { collection, getDocs, setDoc, doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js';
 
+const PERMISSION_GROUPS = {
+  'User Management Rights': [
+    'user.create','user.edit','user.delete','user.activate','user.suspend','user.impersonate','user.view_all','user.bulk_operations','user.invite','user.export'
+  ],
+  'Role & Permission Management Rights': [
+    'role.create','role.edit','role.delete','role.assign','role.revoke','permission.grant','permission.revoke','permission.view'
+  ],
+  'System Administration Rights': [
+    'system.settings','system.backup','system.restore','system.logs','system.maintenance','billing.manage','integration.manage'
+  ],
+  'Department Management Rights': [
+    'department.create','department.edit','department.delete','department.manage_members','department.view_all'
+  ],
+  'Team Management Rights': [
+    'team.create','team.edit','team.delete','team.manage_members','team.assign_lead'
+  ],
+  'Project Management Rights': [
+    'project.create','project.edit','project.delete','project.archive','project.view_all','project.view_assigned'
+  ],
+  'Project Access Rights': [
+    'project.manage_members','project.assign_roles','project.change_settings','project.view_reports'
+  ],
+  'Task Creation & Management Rights': [
+    'task.create','task.edit','task.delete','task.assign','task.reassign','task.clone'
+  ],
+  'Task Status Rights': [
+    'task.close','task.reopen','task.change_status','task.change_priority','task.set_deadline'
+  ],
+  'Task Viewing Rights': [
+    'task.view_all','task.view_assigned','task.view_created','task.view_team'
+  ],
+  'Comment Rights': [
+    'comment.create','comment.edit','comment.edit_all','comment.delete','comment.delete_all','comment.view'
+  ],
+  'File & Attachment Rights': [
+    'attachment.upload','attachment.download','attachment.delete','attachment.view'
+  ],
+  'Report Generation Rights': [
+    'report.view_basic','report.view_advanced','report.create_custom','report.schedule','report.export'
+  ],
+  'Data Access Rights': [
+    'data.export','data.import','audit.view','analytics.view'
+  ],
+  'Security Management Rights': [
+    'security.view_logs','security.manage_sessions','security.ip_restrictions','security.2fa_enforce'
+  ],
+  'Audit & Compliance Rights': [
+    'audit.full_access','audit.user_actions','compliance.gdpr','compliance.export_data'
+  ],
+  'Notification Rights': [
+    'notification.send','notification.broadcast','notification.manage_templates'
+  ],
+  'Integration Rights': [
+    'integration.slack','integration.email','integration.calendar','integration.sso'
+  ],
+  'Time Management Rights': [
+    'time.track','time.edit','time.view_all','time.approve','time.export'
+  ],
+  'Resource Management Rights': [
+    'resource.allocate','resource.view','resource.manage'
+  ],
+  'API Access Rights': [
+    'api.read','api.write','api.admin','webhook.create','webhook.manage'
+  ],
+  'Automation Rights': [
+    'automation.create','automation.edit','automation.execute'
+  ]
+};
+
 const editRoleModal = document.getElementById('editRoleModal');
 const editRoleClose = document.getElementById('editRoleClose');
 const roleForm = document.getElementById('roleForm');
@@ -12,6 +81,14 @@ const rolePermsInput = document.getElementById('rolePerms');
 const roleParentSelect = document.getElementById('roleParent');
 const editRoleTitle = document.getElementById('editRoleTitle');
 const roleCancelBtn = document.getElementById('roleCancel');
+const editPermsBtn = document.getElementById('editPermsBtn');
+
+const permissionsModal = document.getElementById('permissionsModal');
+const permClose = document.getElementById('permClose');
+const permCancel = document.getElementById('permCancel');
+const permSave = document.getElementById('permSave');
+const permSelectAll = document.getElementById('permSelectAll');
+const permissionsContainer = document.getElementById('permissionsContainer');
 let editingRoleId = null;
 
 const tbody = document.getElementById('rolesBody');
@@ -38,6 +115,59 @@ function openModal(modal) {
 function closeModal(modal) {
   modal.classList.remove('active');
   modal.setAttribute('aria-hidden', 'true');
+}
+
+function populatePermissions(selected = []) {
+  permissionsContainer.innerHTML = '';
+  Object.entries(PERMISSION_GROUPS).forEach(([group, perms]) => {
+    const div = document.createElement('div');
+    div.className = 'perm-group';
+    const header = document.createElement('div');
+    header.className = 'perm-group-header';
+    const groupCb = document.createElement('input');
+    groupCb.type = 'checkbox';
+    groupCb.dataset.group = group;
+    groupCb.checked = perms.every(p => selected.includes(p));
+    header.appendChild(groupCb);
+    header.appendChild(document.createTextNode(group));
+    div.appendChild(header);
+    perms.forEach(p => {
+      const label = document.createElement('label');
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.value = p;
+      if (selected.includes(p)) cb.checked = true;
+      label.appendChild(cb);
+      label.appendChild(document.createTextNode(' ' + p));
+      label.className = 'perm-item';
+      cb.className = 'perm-' + group;
+      div.appendChild(label);
+    });
+    permissionsContainer.appendChild(div);
+  });
+  updateSelectAll();
+}
+
+function getSelectedPerms() {
+  return Array.from(permissionsContainer.querySelectorAll('input[type="checkbox"][value]:checked')).map(c => c.value);
+}
+
+function updateGroupState(group) {
+  const boxes = permissionsContainer.querySelectorAll('input.perm-' + CSS.escape(group));
+  const groupCb = permissionsContainer.querySelector('input[data-group="' + CSS.escape(group) + '"]');
+  if (!groupCb) return;
+  groupCb.checked = Array.from(boxes).every(b => b.checked);
+}
+
+function updateSelectAll() {
+  const all = permissionsContainer.querySelectorAll('input[type="checkbox"][value]');
+  permSelectAll.checked = Array.from(all).every(b => b.checked);
+}
+
+function openPermissionsModal() {
+  const selected = rolePermsInput.value.split(',').map(p => p.trim()).filter(Boolean);
+  populatePermissions(selected);
+  openModal(permissionsModal);
 }
 
 async function populateParentRoles(excludeId) {
@@ -80,6 +210,37 @@ tbody.addEventListener('click', e => {
 
 addBtn.addEventListener('click', () => {
   showEditModal();
+});
+
+editPermsBtn.addEventListener('click', openPermissionsModal);
+
+permClose.addEventListener('click', () => closeModal(permissionsModal));
+permCancel.addEventListener('click', () => closeModal(permissionsModal));
+permissionsModal.addEventListener('click', e => { if (e.target === permissionsModal) closeModal(permissionsModal); });
+
+permSave.addEventListener('click', () => {
+  const selected = getSelectedPerms();
+  rolePermsInput.value = selected.join(', ');
+  closeModal(permissionsModal);
+});
+
+permissionsContainer.addEventListener('change', e => {
+  if (e.target.dataset.group) {
+    const group = e.target.dataset.group;
+    permissionsContainer.querySelectorAll('input.perm-' + CSS.escape(group)).forEach(cb => {
+      cb.checked = e.target.checked;
+    });
+  }
+  if (e.target.value) {
+    const group = Array.from(e.target.classList).find(c => c.startsWith('perm-'))?.slice(5);
+    if (group) updateGroupState(group);
+  }
+  updateSelectAll();
+});
+
+permSelectAll.addEventListener('change', () => {
+  const all = permissionsContainer.querySelectorAll('input[type="checkbox"]');
+  all.forEach(cb => { cb.checked = permSelectAll.checked; });
 });
 
 editRoleClose.addEventListener('click', () => closeModal(editRoleModal));

--- a/styles.css
+++ b/styles.css
@@ -1414,6 +1414,35 @@ body {
     color: var(--text-primary);
 }
 
+.large-modal {
+    width: 95%;
+    max-width: 800px;
+}
+
+.permissions-container {
+    max-height: 60vh;
+    overflow-y: auto;
+    padding: 8px 0;
+}
+
+.perm-group {
+    margin-bottom: 16px;
+}
+
+.perm-group-header {
+    font-weight: 600;
+    margin-bottom: 4px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.perm-group label {
+    display: block;
+    margin-left: 20px;
+    font-size: 14px;
+}
+
 /* Insights Modal */
 .insights-modal {
     background: var(--background);
@@ -1851,6 +1880,10 @@ body {
         max-width: none;
         height: 100%;
         border-radius: 0;
+    }
+    .large-modal {
+        width: 100%;
+        max-width: none;
     }
 }
 

--- a/user-management.html
+++ b/user-management.html
@@ -127,7 +127,7 @@
   </div>
 
   <div class="modal-overlay" id="rolesModal" aria-hidden="true">
-    <div class="task-modal">
+    <div class="task-modal large-modal">
       <div class="modal-header">
         <h3>User Roles &amp; Permissions</h3>
         <button class="close-btn" id="rolesClose"><span class="material-icons">close</span></button>


### PR DESCRIPTION
## Summary
- enlarge roles modal and editing modal
- introduce dedicated permissions modal for roles
- provide permission groups with checkboxes
- style new modal controls

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68574ec7df98832e8afa4f438f6b9b13