### PR TITLE
Ensure persistent dark theme across pages

### DIFF
--- a/audit.html
+++ b/audit.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Audit Logs - Mumatec Tasking</title>
+<script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+</script>
   <link id="styleLink" rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/departments.html
+++ b/departments.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Departments & Teams - Mumatec Tasking</title>
+<script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+</script>
   <link id="styleLink" rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="favicon.ico">
     <title>Mumatec Tasking</title>
+<script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+</script>
     <link id="styleLink" rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/invite.html
+++ b/invite.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Invitations - Mumatec Tasking</title>
+<script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+</script>
   <link id="styleLink" rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/login.html
+++ b/login.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login - Mumatec Tasking</title>
+<script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+</script>
   <link id="styleLink" rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/profile.html
+++ b/profile.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Profile - Mumatec Tasking</title>
+<script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+</script>
   <link id="styleLink" rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/reset.html
+++ b/reset.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Reset Password - Mumatec Tasking</title>
+<script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+</script>
   <link id="styleLink" rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/roles-admin.html
+++ b/roles-admin.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Role Administration - Mumatec Tasking</title>
+<script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+</script>
   <link id="styleLink" rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/signup.html
+++ b/signup.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sign Up - Mumatec Tasking</title>
+<script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+</script>
   <link id="styleLink" rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/style.js
+++ b/style.js
@@ -3,18 +3,21 @@
   function updateThemeIcon(){
     const btn = document.getElementById('themeToggle');
     if(btn){
-      btn.innerHTML = `<span class="material-icons">${document.body.classList.contains('dark-mode') ? 'light_mode' : 'dark_mode'}</span>`;
+      const isDark = document.documentElement.classList.contains('dark-mode') || document.body.classList.contains('dark-mode');
+      btn.innerHTML = `<span class="material-icons">${isDark ? 'light_mode' : 'dark_mode'}</span>`;
     }
   }
 
   window.applySavedTheme = function(){
     if(localStorage.getItem('mumatecTheme') === 'dark'){
+      document.documentElement.classList.add('dark-mode');
       document.body.classList.add('dark-mode');
     }
     updateThemeIcon();
   };
 
   window.toggleThemePreference = function(){
+    document.documentElement.classList.toggle('dark-mode');
     const isDark = document.body.classList.toggle('dark-mode');
     localStorage.setItem('mumatecTheme', isDark ? 'dark' : 'light');
     updateThemeIcon();

--- a/styles.css
+++ b/styles.css
@@ -1875,7 +1875,7 @@ body {
 }
 
 /* Manual dark mode toggle */
-body.dark-mode {
+html.dark-mode, body.dark-mode {
     --background: linear-gradient(135deg, #0e5077 0%, #06315e 100%);
     --surface: rgba(9, 45, 71, 0.85);
     --surface-secondary: rgba(9, 45, 71, 0.65);

--- a/user-management.html
+++ b/user-management.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>User Management - Mumatec Tasking</title>
+<script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+</script>
   <link id="styleLink" rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- apply saved dark mode before loading CSS
- support dark mode class on `html` and `body`
- sync style.js logic with new class usage

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68574f0a9090832eb6d580ee07bc6d3d