### PR TITLE
Add role-specific features

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -51,6 +51,8 @@ onAuthStateChanged(auth, async (user) => {
     }
     const nameEl = document.getElementById('userName');
     if (nameEl && name) nameEl.textContent = name;
+    const roleEl = document.getElementById('userRole');
+    if (roleEl && roles.length) roleEl.textContent = roles.join(', ');
     if (typeof window.initTodoApp === 'function') {
       window.initTodoApp();
     }

--- a/client-portal.html
+++ b/client-portal.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Client Portal - Mumatec Tasking</title>
+  <script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+  </script>
+  <link id="styleLink" rel="stylesheet" href="styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="style.js"></script>
+  <script>applySavedTheme(); window.REQUIRED_ROLES = ['client'];</script>
+</head>
+<body>
+  <header class="top-bar">
+    <div class="top-bar-left">
+      <a href="index.html" class="action-btn secondary" aria-label="Back to dashboard"><span class="material-icons">arrow_back</span></a>
+      <h1 class="page-title">Client Portal</h1>
+    </div>
+    <div class="top-bar-right">
+      <div class="user-info" id="userInfo">
+        <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
+        <div class="profile-dropdown" id="profileDropdown">
+          <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+          <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
+          <button class="dropdown-btn" onclick="logout()">Logout</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <div class="app-container">
+    <div class="main-content">
+      <div class="content-area" style="padding:20px;">
+        <p>Your project updates and invoices will appear here.</p>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="auth.js"></script>
+</body>
+</html>

--- a/designer-hub.html
+++ b/designer-hub.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Designer Hub - Mumatec Tasking</title>
+  <script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+  </script>
+  <link id="styleLink" rel="stylesheet" href="styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="style.js"></script>
+  <script>applySavedTheme(); window.REQUIRED_ROLES = ['designer'];</script>
+</head>
+<body>
+  <header class="top-bar">
+    <div class="top-bar-left">
+      <a href="index.html" class="action-btn secondary" aria-label="Back to dashboard"><span class="material-icons">arrow_back</span></a>
+      <h1 class="page-title">Designer Hub</h1>
+    </div>
+    <div class="top-bar-right">
+      <div class="user-info" id="userInfo">
+        <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
+        <div class="profile-dropdown" id="profileDropdown">
+          <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+          <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
+          <button class="dropdown-btn" onclick="logout()">Logout</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <div class="app-container">
+    <div class="main-content">
+      <div class="content-area" style="padding:20px;">
+        <p>Access design resources and style guides here.</p>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="auth.js"></script>
+</body>
+</html>

--- a/developer-tools.html
+++ b/developer-tools.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Developer Tools - Mumatec Tasking</title>
+  <script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+  </script>
+  <link id="styleLink" rel="stylesheet" href="styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="style.js"></script>
+  <script>applySavedTheme(); window.REQUIRED_ROLES = ['developer'];</script>
+</head>
+<body>
+  <header class="top-bar">
+    <div class="top-bar-left">
+      <a href="index.html" class="action-btn secondary" aria-label="Back to dashboard"><span class="material-icons">arrow_back</span></a>
+      <h1 class="page-title">Developer Tools</h1>
+    </div>
+    <div class="top-bar-right">
+      <div class="user-info" id="userInfo">
+        <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
+        <div class="profile-dropdown" id="profileDropdown">
+          <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+          <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
+          <button class="dropdown-btn" onclick="logout()">Logout</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <div class="app-container">
+    <div class="main-content">
+      <div class="content-area" style="padding:20px;">
+        <p>Developer specific resources will appear here.</p>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="auth.js"></script>
+</body>
+</html>

--- a/guest-portal.html
+++ b/guest-portal.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Guest Portal - Mumatec Tasking</title>
+  <script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+  </script>
+  <link id="styleLink" rel="stylesheet" href="styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="style.js"></script>
+  <script>applySavedTheme(); window.REQUIRED_ROLES = ['guest'];</script>
+</head>
+<body>
+  <header class="top-bar">
+    <div class="top-bar-left">
+      <a href="index.html" class="action-btn secondary" aria-label="Back to dashboard"><span class="material-icons">arrow_back</span></a>
+      <h1 class="page-title">Guest Portal</h1>
+    </div>
+    <div class="top-bar-right">
+      <div class="user-info" id="userInfo">
+        <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
+        <div class="profile-dropdown" id="profileDropdown">
+          <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+          <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
+          <button class="dropdown-btn" onclick="logout()">Logout</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <div class="app-container">
+    <div class="main-content">
+      <div class="content-area" style="padding:20px;">
+        <p>This read-only view is provided for guests.</p>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="auth.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -59,6 +59,24 @@
                     <a href="user-management.html" class="dropdown-btn">
                         <span class="material-icons">manage_accounts</span> User Management
                     </a>
+                    <a href="project-dashboard.html" class="dropdown-btn role-link" data-role="projectManager">
+                        <span class="material-icons">dashboard</span> Project Dashboard
+                    </a>
+                    <a href="team-lead.html" class="dropdown-btn role-link" data-role="teamLead">
+                        <span class="material-icons">groups</span> Team Lead Tools
+                    </a>
+                    <a href="developer-tools.html" class="dropdown-btn role-link" data-role="developer">
+                        <span class="material-icons">code</span> Developer Tools
+                    </a>
+                    <a href="designer-hub.html" class="dropdown-btn role-link" data-role="designer">
+                        <span class="material-icons">brush</span> Designer Hub
+                    </a>
+                    <a href="client-portal.html" class="dropdown-btn role-link" data-role="client">
+                        <span class="material-icons">business</span> Client Portal
+                    </a>
+                    <a href="guest-portal.html" class="dropdown-btn role-link" data-role="guest">
+                        <span class="material-icons">visibility</span> Guest Portal
+                    </a>
                     <button class="dropdown-btn" onclick="logout()">Logout</button>
                 </div>
             </div>

--- a/project-dashboard.html
+++ b/project-dashboard.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Project Dashboard - Mumatec Tasking</title>
+  <script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+  </script>
+  <link id="styleLink" rel="stylesheet" href="styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="style.js"></script>
+  <script>applySavedTheme(); window.REQUIRED_ROLES = ['projectManager'];</script>
+</head>
+<body>
+  <header class="top-bar">
+    <div class="top-bar-left">
+      <a href="index.html" class="action-btn secondary" aria-label="Back to dashboard"><span class="material-icons">arrow_back</span></a>
+      <h1 class="page-title">Project Dashboard</h1>
+    </div>
+    <div class="top-bar-right">
+      <div class="user-info" id="userInfo">
+        <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
+        <div class="profile-dropdown" id="profileDropdown">
+          <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+          <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
+          <button class="dropdown-btn" onclick="logout()">Logout</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <div class="app-container">
+    <div class="main-content">
+      <div class="content-area" style="padding:20px;">
+        <p>Welcome to the Project Manager dashboard.</p>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="auth.js"></script>
+</body>
+</html>

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -88,6 +88,8 @@ class MumatecTaskManager {
             month: 'long',
             day: 'numeric'
         });
+
+        this.setupRoleLinks();
     }
 
     // Data Management
@@ -2300,6 +2302,16 @@ class MumatecTaskManager {
                 btn.setAttribute('aria-expanded', String(!collapsed));
             }
         }
+    }
+
+    setupRoleLinks() {
+        const links = document.querySelectorAll('.role-link');
+        links.forEach(link => {
+            const role = link.dataset.role || '';
+            const roles = role.split(',').map(r => r.trim()).filter(Boolean);
+            const visible = roles.some(r => window.currentUserRoles?.includes(r));
+            link.style.display = visible ? 'block' : 'none';
+        });
     }
 
     loadQuickNotes() {

--- a/team-lead.html
+++ b/team-lead.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Team Lead Tools - Mumatec Tasking</title>
+  <script>
+  if (localStorage.getItem('mumatecTheme') === 'dark') {
+    document.documentElement.classList.add('dark-mode');
+  }
+  </script>
+  <link id="styleLink" rel="stylesheet" href="styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="style.js"></script>
+  <script>applySavedTheme(); window.REQUIRED_ROLES = ['teamLead'];</script>
+</head>
+<body>
+  <header class="top-bar">
+    <div class="top-bar-left">
+      <a href="index.html" class="action-btn secondary" aria-label="Back to dashboard"><span class="material-icons">arrow_back</span></a>
+      <h1 class="page-title">Team Lead Tools</h1>
+    </div>
+    <div class="top-bar-right">
+      <div class="user-info" id="userInfo">
+        <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
+        <div class="profile-dropdown" id="profileDropdown">
+          <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+          <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
+          <button class="dropdown-btn" onclick="logout()">Logout</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <div class="app-container">
+    <div class="main-content">
+      <div class="content-area" style="padding:20px;">
+        <p>Welcome to the Team Lead tools section.</p>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="auth.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show user's roles in header
- add placeholder pages for every role
- link to role pages via dropdown
- display role links only for assigned roles

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6857d85aab10832eb0dab2bcdf253f09