### PR TITLE
Add theme selector for multiple design systems

### DIFF
--- a/audit.html
+++ b/audit.html
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme(); window.REQUIRED_ROLES = ['admin','superAdmin'];</script>
+  <script>applySavedTheme();applySavedDesignSystem(); window.REQUIRED_ROLES = ['admin','superAdmin'];</script>
 </head>
 <body>
   <header class="top-bar">
@@ -27,6 +27,11 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                    <select id="designSelect" class="dropdown-select" onchange="changeDesignSystem(this.value)">
+                        <option value="apple">Apple</option>
+                        <option value="material">Google</option>
+                        <option value="samsung">Samsung</option>
+</select>
           <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>

--- a/client-portal.html
+++ b/client-portal.html
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme(); window.REQUIRED_ROLES = ['client'];</script>
+  <script>applySavedTheme();applySavedDesignSystem(); window.REQUIRED_ROLES = ['client'];</script>
 </head>
 <body>
   <header class="top-bar">
@@ -27,6 +27,11 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                    <select id="designSelect" class="dropdown-select" onchange="changeDesignSystem(this.value)">
+                        <option value="apple">Apple</option>
+                        <option value="material">Google</option>
+                        <option value="samsung">Samsung</option>
+</select>
           <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>

--- a/departments.html
+++ b/departments.html
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme(); window.REQUIRED_ROLES = ['admin','superAdmin'];</script>
+  <script>applySavedTheme();applySavedDesignSystem(); window.REQUIRED_ROLES = ['admin','superAdmin'];</script>
 </head>
 <body>
   <header class="top-bar">
@@ -27,6 +27,11 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                    <select id="designSelect" class="dropdown-select" onchange="changeDesignSystem(this.value)">
+                        <option value="apple">Apple</option>
+                        <option value="material">Google</option>
+                        <option value="samsung">Samsung</option>
+</select>
           <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>

--- a/designer-hub.html
+++ b/designer-hub.html
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme(); window.REQUIRED_ROLES = ['designer'];</script>
+  <script>applySavedTheme();applySavedDesignSystem(); window.REQUIRED_ROLES = ['designer'];</script>
 </head>
 <body>
   <header class="top-bar">
@@ -27,6 +27,11 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                    <select id="designSelect" class="dropdown-select" onchange="changeDesignSystem(this.value)">
+                        <option value="apple">Apple</option>
+                        <option value="material">Google</option>
+                        <option value="samsung">Samsung</option>
+</select>
           <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>

--- a/developer-tools.html
+++ b/developer-tools.html
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme(); window.REQUIRED_ROLES = ['developer'];</script>
+  <script>applySavedTheme();applySavedDesignSystem(); window.REQUIRED_ROLES = ['developer'];</script>
 </head>
 <body>
   <header class="top-bar">
@@ -27,6 +27,11 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                    <select id="designSelect" class="dropdown-select" onchange="changeDesignSystem(this.value)">
+                        <option value="apple">Apple</option>
+                        <option value="material">Google</option>
+                        <option value="samsung">Samsung</option>
+</select>
           <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>

--- a/guest-portal.html
+++ b/guest-portal.html
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme(); window.REQUIRED_ROLES = ['guest'];</script>
+  <script>applySavedTheme();applySavedDesignSystem(); window.REQUIRED_ROLES = ['guest'];</script>
 </head>
 <body>
   <header class="top-bar">
@@ -27,6 +27,11 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                    <select id="designSelect" class="dropdown-select" onchange="changeDesignSystem(this.value)">
+                        <option value="apple">Apple</option>
+                        <option value="material">Google</option>
+                        <option value="samsung">Samsung</option>
+</select>
           <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <script src="check-environment.js"></script>
     <script src="style.js"></script>
-    <script>applySavedTheme();</script>
+    <script>applySavedTheme();applySavedDesignSystem();</script>
 </head>
 <body>
     <div id="loadingOverlay" class="loading-overlay" style="display:none;">Loading...</div>
@@ -51,6 +51,11 @@
                 </div>
                 <div class="profile-dropdown" id="profileDropdown">
                     <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                    <select id="designSelect" class="dropdown-select" onchange="changeDesignSystem(this.value)">
+                        <option value="apple">Apple</option>
+                        <option value="material">Google</option>
+                        <option value="samsung">Samsung</option>
+</select>
                     <button class="dropdown-btn" onclick="document.getElementById('csvImport').click()">
                         <span class="material-icons">file_upload</span> Import
                     </button>

--- a/invite.html
+++ b/invite.html
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme(); window.REQUIRED_ROLES = ['admin','superAdmin'];</script>
+  <script>applySavedTheme();applySavedDesignSystem(); window.REQUIRED_ROLES = ['admin','superAdmin'];</script>
 </head>
 <body>
   <header class="top-bar">
@@ -27,6 +27,11 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                    <select id="designSelect" class="dropdown-select" onchange="changeDesignSystem(this.value)">
+                        <option value="apple">Apple</option>
+                        <option value="material">Google</option>
+                        <option value="samsung">Samsung</option>
+</select>
           <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>

--- a/login.html
+++ b/login.html
@@ -16,7 +16,7 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="check-environment.js"></script>
   <script src="style.js"></script>
-  <script>applySavedTheme();</script>
+  <script>applySavedTheme();applySavedDesignSystem();</script>
 </head>
 <body class="auth-page">
   <div class="auth-container">

--- a/profile.html
+++ b/profile.html
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme();</script>
+  <script>applySavedTheme();applySavedDesignSystem();</script>
 </head>
 <body>
   <header class="top-bar">
@@ -27,6 +27,11 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                    <select id="designSelect" class="dropdown-select" onchange="changeDesignSystem(this.value)">
+                        <option value="apple">Apple</option>
+                        <option value="material">Google</option>
+                        <option value="samsung">Samsung</option>
+</select>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>
       </div>

--- a/project-dashboard.html
+++ b/project-dashboard.html
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme(); window.REQUIRED_ROLES = ['projectManager'];</script>
+  <script>applySavedTheme();applySavedDesignSystem(); window.REQUIRED_ROLES = ['projectManager'];</script>
 </head>
 <body>
   <header class="top-bar">
@@ -27,6 +27,11 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                    <select id="designSelect" class="dropdown-select" onchange="changeDesignSystem(this.value)">
+                        <option value="apple">Apple</option>
+                        <option value="material">Google</option>
+                        <option value="samsung">Samsung</option>
+</select>
           <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>

--- a/reset.html
+++ b/reset.html
@@ -15,7 +15,7 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme();</script>
+  <script>applySavedTheme();applySavedDesignSystem();</script>
 </head>
 <body class="auth-page">
   <div class="auth-container">

--- a/roles-admin.html
+++ b/roles-admin.html
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme(); window.REQUIRED_ROLES = ['superAdmin'];</script>
+  <script>applySavedTheme();applySavedDesignSystem(); window.REQUIRED_ROLES = ['superAdmin'];</script>
 </head>
 <body>
   <header class="top-bar">
@@ -27,6 +27,11 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                    <select id="designSelect" class="dropdown-select" onchange="changeDesignSystem(this.value)">
+                        <option value="apple">Apple</option>
+                        <option value="material">Google</option>
+                        <option value="samsung">Samsung</option>
+</select>
           <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>

--- a/signup.html
+++ b/signup.html
@@ -15,7 +15,7 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme();</script>
+  <script>applySavedTheme();applySavedDesignSystem();</script>
 </head>
 <body class="auth-page">
   <div class="auth-container">
@@ -67,10 +67,10 @@
       </div>
       <div class="input-field">
         <select id="status" class="browser-default">
-        <option value="online">Online</option>
-        <option value="offline">Offline</option>
-        <option value="away">Away</option>
-        <option value="busy">Busy</option>
+                            <option value="online">Online</option>
+                            <option value="offline">Offline</option>
+                            <option value="away">Away</option>
+                            <option value="busy">Busy</option>
       </select>
         <label for="status">Status</label>
       </div>

--- a/style.js
+++ b/style.js
@@ -8,6 +8,16 @@
     }
   }
 
+  function applySavedDesignSystem(){
+    const design = localStorage.getItem('designSystem') || 'apple';
+    document.documentElement.classList.remove('apple-theme','material-theme','samsung-theme');
+    document.documentElement.classList.add(`${design}-theme`);
+    const select = document.getElementById('designSelect');
+    if(select){
+      select.value = design;
+    }
+  }
+
   window.applySavedTheme = function(){
     if(localStorage.getItem('mumatecTheme') === 'dark'){
       document.documentElement.classList.add('dark-mode');
@@ -16,10 +26,18 @@
     updateThemeIcon();
   };
 
+  window.applySavedDesignSystem = applySavedDesignSystem;
+
   window.toggleThemePreference = function(){
     document.documentElement.classList.toggle('dark-mode');
     const isDark = document.body.classList.toggle('dark-mode');
     localStorage.setItem('mumatecTheme', isDark ? 'dark' : 'light');
     updateThemeIcon();
   };
+
+  window.changeDesignSystem = function(design){
+    localStorage.setItem('designSystem', design);
+    applySavedDesignSystem();
+  };
+
 })();

--- a/styles.css
+++ b/styles.css
@@ -73,6 +73,30 @@
     --scrollbar-thumb-hover: var(--primary-blue-hover);
 }
 
+html.material-theme {
+    --primary-blue: #1a73e8;
+    --primary-blue-hover: #1765d1;
+    --surface: #ffffff;
+    --surface-secondary: #f5f5f5;
+    --text-primary: #202124;
+    --text-secondary: #5f6368;
+    --font-system: 'Roboto', sans-serif;
+}
+
+html.samsung-theme {
+    --primary-blue: #1428a0;
+    --primary-blue-hover: #1a47d0;
+    --surface: #f7f8fa;
+    --surface-secondary: #ffffff;
+    --text-primary: #000000;
+    --text-secondary: #555555;
+    --font-system: 'Segoe UI', sans-serif;
+}
+
+html.apple-theme {
+    /* uses defaults */
+}
+
 body {
     font-family: var(--font-system);
     background: var(--surface);
@@ -215,8 +239,20 @@ body {
     cursor: pointer;
 }
 
+.profile-dropdown .dropdown-select {
+    display: block;
+    padding: 8px 16px;
+    font-size: 14px;
+    color: var(--text-primary);
+    background: none;
+    border: none;
+    width: 100%;
+    cursor: pointer;
+}
+
 .profile-dropdown a:hover,
-.profile-dropdown .dropdown-btn:hover {
+.profile-dropdown .dropdown-btn:hover,
+.profile-dropdown .dropdown-select:hover {
     background: var(--gray-100);
 }
 

--- a/team-lead.html
+++ b/team-lead.html
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme(); window.REQUIRED_ROLES = ['teamLead'];</script>
+  <script>applySavedTheme();applySavedDesignSystem(); window.REQUIRED_ROLES = ['teamLead'];</script>
 </head>
 <body>
   <header class="top-bar">
@@ -27,6 +27,11 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                    <select id="designSelect" class="dropdown-select" onchange="changeDesignSystem(this.value)">
+                        <option value="apple">Apple</option>
+                        <option value="material">Google</option>
+                        <option value="samsung">Samsung</option>
+</select>
           <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>

--- a/user-management.html
+++ b/user-management.html
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="style.js"></script>
-  <script>applySavedTheme(); window.REQUIRED_ROLES = ['admin', 'superAdmin'];</script>
+  <script>applySavedTheme();applySavedDesignSystem(); window.REQUIRED_ROLES = ['admin', 'superAdmin'];</script>
 </head>
 <body>
   <header class="top-bar">
@@ -27,6 +27,11 @@
         <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
         <div class="profile-dropdown" id="profileDropdown">
           <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                    <select id="designSelect" class="dropdown-select" onchange="changeDesignSystem(this.value)">
+                        <option value="apple">Apple</option>
+                        <option value="material">Google</option>
+                        <option value="samsung">Samsung</option>
+</select>
           <a href="profile.html" class="dropdown-btn"><span class="material-icons">person</span> Profile</a>
           <button class="dropdown-btn" onclick="logout()">Logout</button>
         </div>


### PR DESCRIPTION
## Summary
- add design-system theme classes in CSS
- update script to apply saved design system and switch styles
- insert a design system selector in profile dropdown across pages
- call `applySavedDesignSystem()` on page load

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a9c001e4c832e9b3a72fa9faa90a2