### PR TITLE
Redesign interface with neutral color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <!-- Sticky Header -->
     <header class="top-bar" id="mainHeader">
         <div class="top-bar-left">
-            <button id="sidebarToggle" class="btn-flat waves-effect" aria-label="Toggle navigation menu" aria-expanded="true"><span class="material-icons">menu</span></button>
+            <button id="sidebarToggle" class="btn-flat waves-effect" aria-label="Toggle navigation menu" aria-expanded="true" aria-controls="sidebar" type="button"><span class="material-icons" aria-hidden="true">menu</span></button>
             <h1 class="page-title" id="pageTitle">Mumatec Tasking</h1>
 
         </div>
@@ -34,61 +34,61 @@
 
                 <input type="text" class="search-input" id="searchInput" placeholder="Search tasks..." aria-label="Search tasks">
 
-                <span class="material-icons search-icon">search</span>
+                <span class="material-icons search-icon" aria-hidden="true">search</span>
             </div>
             
         </div>
 
         <div class="top-bar-right">
-            <button class="btn waves-effect waves-light" onclick="todoApp.openAddTaskModal()">
-                <span class="material-icons">add</span> New Task
+            <button class="action-btn primary" onclick="todoApp.openAddTaskModal()" type="button">
+                <span class="material-icons" aria-hidden="true">add</span> New Task
             </button>
             <div class="user-info" id="userInfo">
-                <div class="user-avatar" id="userAvatar"><span class="material-icons">person</span></div>
+                <div class="user-avatar" id="userAvatar"><span class="material-icons" aria-hidden="true">person</span></div>
                 <div class="user-details">
                     <div class="user-name" id="userName">User</div>
                     <div class="user-role" id="userRole">&nbsp;</div>
                 </div>
                 <div class="profile-dropdown" id="profileDropdown">
-                    <button id="themeToggle" class="dropdown-btn"><span class="material-icons">dark_mode</span></button>
+                    <button id="themeToggle" class="dropdown-btn" type="button"><span class="material-icons" aria-hidden="true">dark_mode</span></button>
                     <select id="designSelect" class="dropdown-select" onchange="changeDesignSystem(this.value)">
                         <option value="apple">Apple</option>
                         <option value="material">Google</option>
                         <option value="samsung">Samsung</option>
 </select>
-                    <button class="dropdown-btn" onclick="document.getElementById('csvImport').click()">
-                        <span class="material-icons">file_upload</span> Import
+                    <button class="dropdown-btn" onclick="document.getElementById('csvImport').click()" type="button">
+                        <span class="material-icons" aria-hidden="true">file_upload</span> Import
                     </button>
                     <a href="profile.html" class="dropdown-btn">
-                        <span class="material-icons">person</span> Profile
+                        <span class="material-icons" aria-hidden="true">person</span> Profile
                     </a>
                     <a href="user-management.html" class="dropdown-btn">
-                        <span class="material-icons">manage_accounts</span> User Management
+                        <span class="material-icons" aria-hidden="true">manage_accounts</span> User Management
                     </a>
                     <a href="project-dashboard.html" class="dropdown-btn role-link" data-role="projectManager">
-                        <span class="material-icons">dashboard</span> Project Dashboard
+                        <span class="material-icons" aria-hidden="true">dashboard</span> Project Dashboard
                     </a>
                     <a href="team-lead.html" class="dropdown-btn role-link" data-role="teamLead">
-                        <span class="material-icons">groups</span> Team Lead Tools
+                        <span class="material-icons" aria-hidden="true">groups</span> Team Lead Tools
                     </a>
                     <a href="developer-tools.html" class="dropdown-btn role-link" data-role="developer">
-                        <span class="material-icons">code</span> Developer Tools
+                        <span class="material-icons" aria-hidden="true">code</span> Developer Tools
                     </a>
                     <a href="designer-hub.html" class="dropdown-btn role-link" data-role="designer">
-                        <span class="material-icons">brush</span> Designer Hub
+                        <span class="material-icons" aria-hidden="true">brush</span> Designer Hub
                     </a>
                     <a href="client-portal.html" class="dropdown-btn role-link" data-role="client">
-                        <span class="material-icons">business</span> Client Portal
+                        <span class="material-icons" aria-hidden="true">business</span> Client Portal
                     </a>
                     <a href="guest-portal.html" class="dropdown-btn role-link" data-role="guest">
-                        <span class="material-icons">visibility</span> Guest Portal
+                        <span class="material-icons" aria-hidden="true">visibility</span> Guest Portal
                     </a>
-                    <button class="dropdown-btn" onclick="logout()">Logout</button>
+                    <button class="dropdown-btn" onclick="logout()" type="button">Logout</button>
                 </div>
             </div>
             <div class="view-controls">
-                <button class="view-btn active material-icons" data-view="kanban" aria-label="Kanban view" aria-pressed="true">view_kanban</button>
-                <button class="view-btn material-icons" data-view="list" aria-label="List view" aria-pressed="false">view_list</button>
+                <button class="view-btn active" data-view="kanban" aria-label="Kanban view" aria-pressed="true" type="button"><span class="material-icons" aria-hidden="true">view_kanban</span></button>
+                <button class="view-btn" data-view="list" aria-label="List view" aria-pressed="false" type="button"><span class="material-icons" aria-hidden="true">view_list</span></button>
             </div>
         </div>
     </header>
@@ -96,28 +96,28 @@
     <!-- App Shell -->
     <div class="app-container">
         <!-- Sidebar -->
-        <div class="sidebar">
+        <div class="sidebar" id="sidebar">
 
 
             <div class="sidebar-nav">
                 <div class="nav-section">
                     <div class="nav-item active" data-view="dashboard" aria-label="Mumatec Tasking">
-                        <span class="material-icons nav-icon">dashboard</span>
+                        <span class="material-icons nav-icon" aria-hidden="true">dashboard</span>
                         <span class="nav-label">Mumatec Tasking</span>
                         <span class="nav-count" id="dashboardCount">0</span>
                     </div>
                     <div class="nav-item" data-view="today" aria-label="Today">
-                        <span class="material-icons nav-icon">today</span>
+                        <span class="material-icons nav-icon" aria-hidden="true">today</span>
                         <span class="nav-label">Today</span>
                         <span class="nav-count" id="todayCount">0</span>
                     </div>
                     <div class="nav-item" data-view="upcoming" aria-label="Upcoming">
-                        <span class="material-icons nav-icon">schedule</span>
+                        <span class="material-icons nav-icon" aria-hidden="true">schedule</span>
                         <span class="nav-label">Upcoming</span>
                         <span class="nav-count" id="upcomingCount">0</span>
                     </div>
                     <div class="nav-item" data-view="completed" aria-label="Completed">
-                        <span class="material-icons nav-icon">check_circle</span>
+                        <span class="material-icons nav-icon" aria-hidden="true">check_circle</span>
                         <span class="nav-label">Completed</span>
                         <span class="nav-count" id="completedNavCount">0</span>
                     </div>
@@ -135,11 +135,11 @@
 
                 <div class="nav-section">
                     <div class="nav-item" onclick="todoApp.openQuickCapture()" aria-label="Quick Capture">
-                        <span class="material-icons nav-icon">flash_on</span>
+                        <span class="material-icons nav-icon" aria-hidden="true">flash_on</span>
                         <span class="nav-label">Quick Capture</span>
                     </div>
                     <div class="nav-item" onclick="todoApp.exportToCSV()" aria-label="Export Data">
-                        <span class="material-icons nav-icon">file_download</span>
+                        <span class="material-icons nav-icon" aria-hidden="true">file_download</span>
                         <span class="nav-label">Export Data</span>
                     </div>
                 </div>
@@ -195,13 +195,13 @@
                                     <div class="column-title">Todo</div>
                                     <div class="column-count" id="todoCount">0</div>
                                     <div class="column-controls">
-                                        <button class="move-btn move-col" data-status="todo" data-direction="left" aria-label="Move column left"><span class="material-icons">arrow_left</span></button>
-                                        <button class="move-btn move-col" data-status="todo" data-direction="right" aria-label="Move column right"><span class="material-icons">arrow_right</span></button>
+                                        <button class="move-btn move-col" data-status="todo" data-direction="left" aria-label="Move column left" type="button"><span class="material-icons" aria-hidden="true">arrow_left</span></button>
+                                        <button class="move-btn move-col" data-status="todo" data-direction="right" aria-label="Move column right" type="button"><span class="material-icons" aria-hidden="true">arrow_right</span></button>
                                     </div>
                                 </div>
                                 <div class="column-content" id="todoBoard">
                                     <div class="add-task-card" onclick="todoApp.openAddTaskModal('todo')">
-                                        <span class="material-icons add-icon">add</span>
+                                        <span class="material-icons add-icon" aria-hidden="true">add</span>
 
                                         <span>Add task</span>
 
@@ -214,13 +214,13 @@
                                     <div class="column-title">In Progress</div>
                                     <div class="column-count" id="inprogressCount">0</div>
                                     <div class="column-controls">
-                                        <button class="move-btn move-col" data-status="inprogress" data-direction="left" aria-label="Move column left"><span class="material-icons">arrow_left</span></button>
-                                        <button class="move-btn move-col" data-status="inprogress" data-direction="right" aria-label="Move column right"><span class="material-icons">arrow_right</span></button>
+                                        <button class="move-btn move-col" data-status="inprogress" data-direction="left" aria-label="Move column left" type="button"><span class="material-icons" aria-hidden="true">arrow_left</span></button>
+                                        <button class="move-btn move-col" data-status="inprogress" data-direction="right" aria-label="Move column right" type="button"><span class="material-icons" aria-hidden="true">arrow_right</span></button>
                                     </div>
                                 </div>
                                 <div class="column-content" id="inprogressBoard">
                                     <div class="add-task-card" onclick="todoApp.openAddTaskModal('inprogress')">
-                                        <span class="material-icons add-icon">add</span>
+                                        <span class="material-icons add-icon" aria-hidden="true">add</span>
 
                                         <span>Add task</span>
                                     </div>
@@ -232,13 +232,13 @@
                                     <div class="column-title">Done</div>
                                     <div class="column-count" id="doneCount">0</div>
                                     <div class="column-controls">
-                                        <button class="move-btn move-col" data-status="done" data-direction="left" aria-label="Move column left"><span class="material-icons">arrow_left</span></button>
-                                        <button class="move-btn move-col" data-status="done" data-direction="right" aria-label="Move column right"><span class="material-icons">arrow_right</span></button>
+                                        <button class="move-btn move-col" data-status="done" data-direction="left" aria-label="Move column left" type="button"><span class="material-icons" aria-hidden="true">arrow_left</span></button>
+                                        <button class="move-btn move-col" data-status="done" data-direction="right" aria-label="Move column right" type="button"><span class="material-icons" aria-hidden="true">arrow_right</span></button>
                                     </div>
                                 </div>
                                 <div class="column-content" id="doneBoard">
                                     <div class="add-task-card" onclick="todoApp.openAddTaskModal('done')">
-                                        <span class="material-icons add-icon">add</span>
+                                        <span class="material-icons add-icon" aria-hidden="true">add</span>
 
                                         <span>Add task</span>
 
@@ -251,13 +251,13 @@
                                     <div class="column-title">Under Review</div>
                                     <div class="column-count" id="reviewCount">0</div>
                                     <div class="column-controls">
-                                        <button class="move-btn move-col" data-status="review" data-direction="left" aria-label="Move column left"><span class="material-icons">arrow_left</span></button>
-                                        <button class="move-btn move-col" data-status="review" data-direction="right" aria-label="Move column right"><span class="material-icons">arrow_right</span></button>
+                                        <button class="move-btn move-col" data-status="review" data-direction="left" aria-label="Move column left" type="button"><span class="material-icons" aria-hidden="true">arrow_left</span></button>
+                                        <button class="move-btn move-col" data-status="review" data-direction="right" aria-label="Move column right" type="button"><span class="material-icons" aria-hidden="true">arrow_right</span></button>
                                     </div>
                                 </div>
                                 <div class="column-content" id="reviewBoard">
                                     <div class="add-task-card" onclick="todoApp.openAddTaskModal('review')">
-                                        <span class="material-icons add-icon">add</span>
+                                        <span class="material-icons add-icon" aria-hidden="true">add</span>
 
                                         <span>Add task</span>
 
@@ -270,13 +270,13 @@
                                     <div class="column-title">Blocked</div>
                                     <div class="column-count" id="blockedCount">0</div>
                                     <div class="column-controls">
-                                        <button class="move-btn move-col" data-status="blocked" data-direction="left" aria-label="Move column left"><span class="material-icons">arrow_left</span></button>
-                                        <button class="move-btn move-col" data-status="blocked" data-direction="right" aria-label="Move column right"><span class="material-icons">arrow_right</span></button>
+                                        <button class="move-btn move-col" data-status="blocked" data-direction="left" aria-label="Move column left" type="button"><span class="material-icons" aria-hidden="true">arrow_left</span></button>
+                                        <button class="move-btn move-col" data-status="blocked" data-direction="right" aria-label="Move column right" type="button"><span class="material-icons" aria-hidden="true">arrow_right</span></button>
                                     </div>
                                 </div>
                                 <div class="column-content" id="blockedBoard">
                                     <div class="add-task-card" onclick="todoApp.openAddTaskModal('blocked')">
-                                        <span class="material-icons add-icon">add</span>
+                                        <span class="material-icons add-icon" aria-hidden="true">add</span>
 
                                         <span>Add task</span>
 
@@ -289,13 +289,13 @@
                                     <div class="column-title">Cancelled</div>
                                     <div class="column-count" id="cancelledCount">0</div>
                                     <div class="column-controls">
-                                        <button class="move-btn move-col" data-status="cancelled" data-direction="left" aria-label="Move column left"><span class="material-icons">arrow_left</span></button>
-                                        <button class="move-btn move-col" data-status="cancelled" data-direction="right" aria-label="Move column right"><span class="material-icons">arrow_right</span></button>
+                                        <button class="move-btn move-col" data-status="cancelled" data-direction="left" aria-label="Move column left" type="button"><span class="material-icons" aria-hidden="true">arrow_left</span></button>
+                                        <button class="move-btn move-col" data-status="cancelled" data-direction="right" aria-label="Move column right" type="button"><span class="material-icons" aria-hidden="true">arrow_right</span></button>
                                     </div>
                                 </div>
                                 <div class="column-content" id="cancelledBoard">
                                     <div class="add-task-card" onclick="todoApp.openAddTaskModal('cancelled')">
-                                        <span class="material-icons add-icon">add</span>
+                                        <span class="material-icons add-icon" aria-hidden="true">add</span>
 
                                         <span>Add task</span>
 
@@ -340,8 +340,8 @@
     <div class="modal-overlay" id="quickCaptureModal" role="dialog" aria-hidden="true">
         <div class="quick-capture-modal">
             <div class="quick-capture-header">
-                <h3><span class="material-icons">flash_on</span> Quick Capture</h3>
-                <button class="close-btn" onclick="todoApp.closeQuickCapture()"><span class="material-icons">close</span></button>
+                <h3><span class="material-icons" aria-hidden="true">flash_on</span> Quick Capture</h3>
+                <button class="close-btn" onclick="todoApp.closeQuickCapture()" type="button"><span class="material-icons" aria-hidden="true">close</span></button>
             </div>
             <input type="text" class="quick-input" id="quickTaskInput" placeholder="What needs to be done?">
             <input type="date" class="quick-input" id="quickTaskDueDate">
@@ -362,8 +362,8 @@
         <div class="task-modal">
             <div class="modal-header">
                 <h3 id="modalTitle">Add New Task</h3>
-                <button type="button" id="watchTaskBtn" class="watch-btn" aria-label="Watch task"><span class="material-icons">notifications_off</span></button>
-                <button class="close-btn" onclick="todoApp.closeModal()"><span class="material-icons">close</span></button>
+                <button type="button" id="watchTaskBtn" class="watch-btn" aria-label="Watch task"><span class="material-icons" aria-hidden="true">notifications_off</span></button>
+                <button class="close-btn" onclick="todoApp.closeModal()" type="button"><span class="material-icons" aria-hidden="true">close</span></button>
             </div>
             <div class="hint-banner">Fill in the essentials. You can edit details later.</div>
             <div class="tab-header" role="tablist">
@@ -469,7 +469,7 @@
         <div class="insights-modal">
             <div class="modal-header">
                 <h3 id="insightsTitle"><span class="material-icons">bar_chart</span> Insights</h3>
-                <button class="close-btn" id="insightsClose" aria-label="Close insights" onclick="todoApp.closeInsights()"><span class="material-icons">close</span></button>
+                <button class="close-btn" id="insightsClose" aria-label="Close insights" onclick="todoApp.closeInsights()" type="button"><span class="material-icons" aria-hidden="true">close</span></button>
             </div>
             <div class="insights-grid">
                 <div class="insight-metric">

--- a/styles.css
+++ b/styles.css
@@ -7,41 +7,39 @@
 }
 
 :root {
-    /* Modern Apple Color Palette */
-    --primary-blue: #24a1c6;
-    --primary-blue-hover: #4db8d9;
-    --secondary-blue: #0e5077;
+    /* Core color palette */
+    --primary-blue: #1e88e5;
+    --primary-blue-hover: #1565c0;
+    --secondary-blue: #0d47a1;
     --success-green: #10b981;
-    --warning-orange: #FF9500;
-    --warning-yellow: #FFD60A;
-    --error-red: #FF3B30;
-    --critical-red: #B00020;
-    --purple: #AF52DE;
-    
+    --warning-orange: #f59e0b;
+    --warning-yellow: #facc15;
+    --error-red: #ef4444;
+    --critical-red: #b91c1c;
+    --purple: #8b5cf6;
+
     /* Neutral Colors */
-    --gray-50: #F9F9F9;
-    --gray-100: #F2F2F2;
-    --gray-200: #E5E5E5;
-    --gray-300: #D1D1D1;
-    --gray-400: #A1A1A1;
-    --gray-500: #737373;
-    --gray-600: #525252;
-    --gray-700: #404040;
-    --gray-800: #262626;
-    --gray-900: #171717;
-    
+    --gray-50: #f8fafc;
+    --gray-100: #f1f5f9;
+    --gray-200: #e2e8f0;
+    --gray-300: #cbd5e1;
+    --gray-400: #94a3b8;
+    --gray-500: #64748b;
+    --gray-600: #475569;
+    --gray-700: #334155;
+    --gray-800: #1e293b;
+    --gray-900: #0f172a;
+
     /* Semantic Colors */
-    --background: rgba(255, 255, 255, 0.7);
-    --surface: radial-gradient(circle at 20% 20%, rgba(36, 161, 198, 0.1) 0%, transparent 50%),
-               radial-gradient(circle at 80% 80%, rgba(14, 80, 119, 0.08) 0%, transparent 50%),
-               linear-gradient(135deg, #f0f7fa 0%, #e6f3f8 50%, #ddeef5 100%);
-    --surface-secondary: rgba(255, 255, 255, 0.5);
-    --text-primary: #06315e;
-    --text-secondary: #5a7a8a;
-    --text-tertiary: #7d9aaa;
-    --border: rgba(255, 255, 255, 0.9);
-    --shadow: rgba(14, 80, 119, 0.05);
-    --shadow-hover: rgba(14, 80, 119, 0.12);
+    --background: var(--gray-50);
+    --surface: #ffffff;
+    --surface-secondary: var(--gray-100);
+    --text-primary: var(--gray-800);
+    --text-secondary: var(--gray-600);
+    --text-tertiary: var(--gray-500);
+    --border: var(--gray-200);
+    --shadow: rgba(15, 23, 42, 0.04);
+    --shadow-hover: rgba(15, 23, 42, 0.1);
     
     /* Layout */
     --sidebar-width: 280px;
@@ -75,21 +73,25 @@
 
 html.material-theme {
     --primary-blue: #1a73e8;
-    --primary-blue-hover: #1765d1;
+    --primary-blue-hover: #165dc2;
     --surface: #ffffff;
-    --surface-secondary: #f5f5f5;
+    --surface-secondary: #f1f3f4;
     --text-primary: #202124;
     --text-secondary: #5f6368;
+    --text-tertiary: #7c7c7c;
+    --border: #dadce0;
     --font-system: 'Roboto', sans-serif;
 }
 
 html.samsung-theme {
     --primary-blue: #1428a0;
     --primary-blue-hover: #1a47d0;
-    --surface: #f7f8fa;
-    --surface-secondary: #ffffff;
+    --surface: #ffffff;
+    --surface-secondary: #f5f7fa;
     --text-primary: #000000;
     --text-secondary: #555555;
+    --text-tertiary: #777777;
+    --border: #e5e7eb;
     --font-system: 'Segoe UI', sans-serif;
 }
 
@@ -99,7 +101,7 @@ html.apple-theme {
 
 body {
     font-family: var(--font-system);
-    background: var(--surface);
+    background: var(--background);
     color: var(--text-primary);
     overflow: hidden;
     -webkit-font-smoothing: antialiased;
@@ -143,9 +145,8 @@ body {
 /* Sidebar */
 .sidebar {
     width: var(--sidebar-width);
-    background: var(--background);
+    background: var(--surface);
     border-right: 1px solid var(--border);
-    backdrop-filter: blur(15px);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -312,8 +313,8 @@ body {
 }
 
 .nav-item:hover {
-    background: var(--gray-100);
-    color: var(--primary-blue);
+    background: var(--surface-secondary);
+    color: var(--text-primary);
 }
 
 .nav-item.active {
@@ -439,9 +440,9 @@ body {
     left: 0;
     width: 100%;
     height: var(--top-bar-height);
-    background: var(--background);
+    background: var(--surface);
     border-bottom: 1px solid var(--border);
-    backdrop-filter: blur(20px);
+    box-shadow: 0 1px 2px var(--shadow);
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -451,7 +452,7 @@ body {
 }
 
 .top-bar.sticky-active {
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 2px 4px var(--shadow-hover);
 }
 
 .top-bar-left {
@@ -603,19 +604,20 @@ body {
 }
 
 .stat-card {
-    background: var(--background);
+    background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--border-radius);
-    padding: 12px;
+    padding: 16px;
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 12px;
+    box-shadow: 0 1px 2px var(--shadow);
     transition: var(--transition);
 }
 
 .stat-card:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 25px var(--shadow-hover);
+    box-shadow: 0 4px 12px var(--shadow-hover);
 }
 
 .stat-icon {
@@ -665,7 +667,7 @@ body {
 }
 
 .kanban-column {
-    background: var(--background);
+    background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--border-radius);
     display: flex;
@@ -674,7 +676,7 @@ body {
     flex: 0 0 var(--kanban-column-width);
     min-width: var(--kanban-column-width);
     position: relative;
-    box-shadow: 0 1px 3px var(--shadow);
+    box-shadow: 0 1px 2px var(--shadow);
 }
 
 .kanban-column:not(:last-child)::after {


### PR DESCRIPTION
## Summary
- Introduce neutral color palette and simplified theme variables
- Restyle top bar, sidebar, navigation, stat cards and kanban columns for a cleaner layout
- Replace Materialize button with custom action button on new task control

## Testing
- `npx --yes htmlhint index.html`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68970fe3cd60832eb1161be80da254eb