### PR TITLE
Redesign project dashboard into kanban workspace

### DIFF
--- a/project-dashboard.html
+++ b/project-dashboard.html
@@ -24,104 +24,124 @@
     <div id="appShellSidebar"></div>
 
     <div class="main-content">
-      <div class="content-area hosting-content">
-        <section class="hosting-hero">
-          <div class="hero-headline">
-            <div>
-              <h2>Platform Health Overview</h2>
-              <p>Real-time visibility into uptime, incidents, billing, and deployment automation.</p>
-            </div>
-            <nav class="hosting-nav" aria-label="Hosting shortcuts">
-              <a class="hosting-nav-link" href="#environments"><span class="material-icons" aria-hidden="true">dns</span>Environments</a>
-              <a class="hosting-nav-link" href="#clients"><span class="material-icons" aria-hidden="true">groups</span>Clients</a>
-              <a class="hosting-nav-link" href="#billing"><span class="material-icons" aria-hidden="true">receipt_long</span>Billing</a>
-            </nav>
+      <div class="content-area workspace-surface">
+        <section class="workspace-hero">
+          <div class="workspace-meta">
+            <p class="workspace-breadcrumb">Clients / Filters / What's My SERP</p>
+            <h1>What's My SERP</h1>
+            <p>Bring hosting, billing, and creative delivery together in one calm command center.</p>
           </div>
-          <div class="metric-grid" role="list">
-            <article class="metric-card" role="listitem">
-              <div class="metric-icon uptime"><span class="material-icons" aria-hidden="true">speed</span></div>
-              <div class="metric-body">
-                <h3>Global Uptime</h3>
-                <p class="metric-value" id="uptimeValue">99.99%</p>
-                <p class="metric-subtitle" id="uptimeSubtitle">Across all monitored regions</p>
-              </div>
-            </article>
-            <article class="metric-card" role="listitem">
-              <div class="metric-icon incidents"><span class="material-icons" aria-hidden="true">warning_amber</span></div>
-              <div class="metric-body">
-                <h3>Open Incidents</h3>
-                <p class="metric-value" id="incidentsValue">0</p>
-                <p class="metric-subtitle" id="incidentsSubtitle">All services operational</p>
-              </div>
-            </article>
-            <article class="metric-card" role="listitem">
-              <div class="metric-icon plans"><span class="material-icons" aria-hidden="true">hub</span></div>
-              <div class="metric-body">
-                <h3>Active Plans</h3>
-                <p class="metric-value" id="plansValue">0</p>
-                <p class="metric-subtitle" id="plansSubtitle">Managed client subscriptions</p>
-              </div>
-            </article>
+          <div class="workspace-quick-actions" aria-label="Quick actions">
+            <button class="chip-button">
+              <span class="material-icons" aria-hidden="true">add</span>
+              New Request
+            </button>
+            <button class="chip-button ghost">
+              <span class="material-icons" aria-hidden="true">ios_share</span>
+              Share Board
+            </button>
           </div>
         </section>
 
-        <div class="hosting-grid">
-          <section class="panel" id="environments">
-            <header class="panel-header">
-              <div>
-                <h2>Environment Status</h2>
-                <p>Monitor server uptime, regional health, and automation checks.</p>
-              </div>
-              <button class="action-btn tertiary" id="refreshEnvironments" type="button">
-                <span class="material-icons" aria-hidden="true">refresh</span>
-                Refresh
+        <section class="workspace-summary" aria-label="Key signals">
+          <article class="summary-card">
+            <div>
+              <p class="summary-label">Global Uptime</p>
+              <p class="summary-value" id="uptimeValue">99.99%</p>
+            </div>
+            <p class="summary-meta" id="uptimeSubtitle">Across all monitored regions</p>
+          </article>
+          <article class="summary-card">
+            <div>
+              <p class="summary-label">Open Incidents</p>
+              <p class="summary-value" id="incidentsValue">0</p>
+            </div>
+            <p class="summary-meta" id="incidentsSubtitle">All services operational</p>
+          </article>
+          <article class="summary-card">
+            <div>
+              <p class="summary-label">Active Plans</p>
+              <p class="summary-value" id="plansValue">0</p>
+            </div>
+            <p class="summary-meta" id="plansSubtitle">Managed client subscriptions</p>
+          </article>
+        </section>
+
+        <section class="workspace-board" aria-labelledby="workspaceBoardTitle">
+          <header class="workspace-board-header">
+            <div>
+              <p class="workspace-board-label">Pipeline overview</p>
+              <h2 id="workspaceBoardTitle">Requests &amp; Delivery</h2>
+            </div>
+            <div class="workspace-board-filters" aria-label="Board filters">
+              <button class="chip-button ghost">All clients</button>
+              <button class="chip-button ghost">Design system</button>
+              <button class="chip-button ghost">Weekly view</button>
+            </div>
+          </header>
+
+          <div class="board-columns" role="list">
+            <article class="board-column column-get-started" role="listitem">
+              <header>
+                <div>
+                  <p class="column-label">Get Started</p>
+                  <p class="column-meta">Kickoff requests waiting on scoping</p>
+                </div>
+                <span class="column-count" id="count-get-started">0</span>
+              </header>
+              <div class="column-cards" id="column-get-started"></div>
+              <button class="column-add" type="button">
+                <span class="material-icons" aria-hidden="true">add</span>
+                Add task
               </button>
-            </header>
-            <div class="environment-grid" id="environmentGrid" role="list"></div>
-          </section>
+            </article>
 
-          <section class="panel" id="deployments">
-            <header class="panel-header">
-              <div>
-                <h2>Deployment Timeline</h2>
-                <p>Track recent launches and automation rollouts.</p>
-              </div>
-            </header>
-            <ol class="timeline" id="deploymentTimeline" aria-live="polite"></ol>
-          </section>
+            <article class="board-column column-backlog" role="listitem">
+              <header>
+                <div>
+                  <p class="column-label">Requests Backlog</p>
+                  <p class="column-meta">Prioritized briefs ready for review</p>
+                </div>
+                <span class="column-count" id="count-requests">0</span>
+              </header>
+              <div class="column-cards" id="column-requests"></div>
+              <button class="column-add" type="button">
+                <span class="material-icons" aria-hidden="true">add</span>
+                Add task
+              </button>
+            </article>
 
-          <section class="panel" id="automation">
-            <header class="panel-header">
-              <div>
-                <h2>Automation Queue</h2>
-                <p>Review active jobs from CI/CD, backups, and compliance scripts.</p>
-              </div>
-            </header>
-            <div class="list-group" id="automationQueue" role="list"></div>
-          </section>
-        </div>
+            <article class="board-column column-progress" role="listitem">
+              <header>
+                <div>
+                  <p class="column-label">In Progress</p>
+                  <p class="column-meta">Active production and build work</p>
+                </div>
+                <span class="column-count" id="count-progress">0</span>
+              </header>
+              <div class="column-cards" id="column-progress"></div>
+              <button class="column-add" type="button">
+                <span class="material-icons" aria-hidden="true">add</span>
+                Add task
+              </button>
+            </article>
 
-        <div class="hosting-grid two-column">
-          <section class="panel" id="clients">
-            <header class="panel-header">
-              <div>
-                <h2>Client Portfolio</h2>
-                <p>Sites by plan tier and current health signals.</p>
-              </div>
-            </header>
-            <div class="list-group" id="clientList" role="list"></div>
-          </section>
-
-          <section class="panel" id="billing">
-            <header class="panel-header">
-              <div>
-                <h2>Billing &amp; Renewals</h2>
-                <p>Upcoming invoices and plan commitments.</p>
-              </div>
-            </header>
-            <div class="list-group" id="billingList" role="list"></div>
-          </section>
-        </div>
+            <article class="board-column column-approved" role="listitem">
+              <header>
+                <div>
+                  <p class="column-label">Approved</p>
+                  <p class="column-meta">Scheduled for delivery or launch</p>
+                </div>
+                <span class="column-count" id="count-approved">0</span>
+              </header>
+              <div class="column-cards" id="column-approved"></div>
+              <button class="column-add" type="button">
+                <span class="material-icons" aria-hidden="true">add</span>
+                Add task
+              </button>
+            </article>
+          </div>
+        </section>
       </div>
     </div>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -2846,6 +2846,321 @@ html.dark-mode, body.dark-mode {
 
 
 /* Hosting Control Center */
+/* Workspace board refresh */
+.workspace-surface {
+    background: radial-gradient(circle at top left, rgba(255, 200, 199, 0.35), transparent 40%),
+      radial-gradient(circle at top right, rgba(196, 223, 255, 0.4), transparent 45%),
+      radial-gradient(circle at bottom left, rgba(197, 255, 213, 0.35), transparent 45%),
+      var(--background);
+    min-height: calc(100vh - var(--top-bar-height));
+    padding: 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+}
+
+.workspace-hero {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 20px;
+    padding: 28px 32px;
+    border-radius: 32px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.55));
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    box-shadow: 0 25px 65px rgba(15, 23, 42, 0.12);
+}
+
+.workspace-meta h1 {
+    font-size: 32px;
+    margin-bottom: 8px;
+}
+
+.workspace-breadcrumb {
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    font-size: 11px;
+    color: var(--text-secondary);
+    margin-bottom: 10px;
+}
+
+.workspace-quick-actions {
+    display: flex;
+    gap: 10px;
+}
+
+.chip-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: 999px;
+    border: none;
+    background: #fff;
+    color: var(--text-primary);
+    font-weight: 600;
+    font-size: 14px;
+    padding: 10px 18px;
+    box-shadow: 0 12px 25px rgba(15, 23, 42, 0.12);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chip-button.ghost {
+    background: transparent;
+    box-shadow: none;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.chip-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 15px 35px rgba(15, 23, 42, 0.18);
+}
+
+.workspace-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+}
+
+.summary-card {
+    background: rgba(255, 255, 255, 0.85);
+    border-radius: 24px;
+    padding: 20px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.7);
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+}
+
+.summary-label {
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: var(--text-secondary);
+}
+
+.summary-value {
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.summary-meta {
+    font-size: 14px;
+    color: var(--text-secondary);
+}
+
+.workspace-board {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 32px;
+    padding: 28px;
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    box-shadow: 0 35px 65px rgba(15, 23, 42, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+}
+
+.workspace-board-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: center;
+}
+
+.workspace-board-label {
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    font-size: 11px;
+    color: var(--text-secondary);
+    margin-bottom: 6px;
+}
+
+.workspace-board-filters {
+    display: flex;
+    gap: 8px;
+}
+
+.board-columns {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 18px;
+}
+
+.board-column {
+    background: rgba(248, 250, 252, 0.9);
+    border-radius: 28px;
+    padding: 20px;
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.column-get-started { background: linear-gradient(180deg, rgba(255, 246, 235, 0.9), rgba(255, 255, 255, 0.9)); }
+.column-backlog { background: linear-gradient(180deg, rgba(236, 248, 255, 0.92), rgba(255, 255, 255, 0.95)); }
+.column-progress { background: linear-gradient(180deg, rgba(235, 245, 255, 0.92), rgba(255, 255, 255, 0.95)); }
+.column-approved { background: linear-gradient(180deg, rgba(240, 255, 246, 0.92), rgba(255, 255, 255, 0.95)); }
+
+.board-column header {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: flex-start;
+}
+
+.column-label {
+    font-size: 16px;
+    font-weight: 700;
+}
+
+.column-meta {
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.column-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 32px;
+    height: 32px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.8);
+    font-weight: 600;
+}
+
+.column-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.column-add {
+    border: 1px dashed rgba(148, 163, 184, 0.6);
+    border-radius: 16px;
+    padding: 10px 14px;
+    background: transparent;
+    font-weight: 600;
+    color: var(--text-secondary);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+}
+
+.task-card {
+    background: #fff;
+    border-radius: 20px;
+    padding: 16px;
+    box-shadow: 0 20px 30px rgba(15, 23, 42, 0.08);
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.task-card header {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.task-indicator {
+    width: 32px;
+    height: 32px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    background: rgba(15, 23, 42, 0.06);
+}
+
+.task-indicator[data-column="get-started"] {
+    color: #d97706;
+    background: rgba(249, 115, 22, 0.12);
+}
+
+.task-indicator[data-column="requests"] {
+    color: #2563eb;
+    background: rgba(59, 130, 246, 0.12);
+}
+
+.task-indicator[data-column="progress"] {
+    color: #0f766e;
+    background: rgba(45, 212, 191, 0.12);
+}
+
+.task-indicator[data-column="approved"] {
+    color: #15803d;
+    background: rgba(34, 197, 94, 0.12);
+}
+
+.task-title {
+    font-weight: 700;
+    font-size: 15px;
+}
+
+.task-subtitle {
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.task-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.task-tag {
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 12px;
+    background: rgba(15, 23, 42, 0.05);
+    color: var(--text-secondary);
+}
+
+.task-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.task-owner {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.task-date {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.empty-state.soft {
+    border-color: rgba(148, 163, 184, 0.4);
+    background: rgba(255, 255, 255, 0.6);
+}
+
+@media (max-width: 900px) {
+    .workspace-surface {
+        padding: 20px;
+    }
+
+    .workspace-hero {
+        border-radius: 24px;
+    }
+
+    .workspace-board {
+        padding: 20px;
+    }
+}
+
 .hosting-shell {
     background: var(--background);
     overflow-y: auto;


### PR DESCRIPTION
## Summary
- replace the project dashboard layout with a kanban-inspired workspace experience including hero, summary stats, and request columns
- add new gradient board styles, chip buttons, and task card components to match the requested visual reference
- update the hosting management script to drive the new board, provide fallback sample data, and keep hero metrics in sync

## Testing
- npm run dev

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a00c0c27c832eb44a35d4716d6b14)